### PR TITLE
Handle paths with space in config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,133 @@ __pycache__/
 *.py[cod]
 .idea
 
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+junit/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/_apidoc/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# -- CUSTOM ----
+*.zip
+*.qm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,56 @@
+exclude: ".venv|__pycache__|tests/dev/|tests/fixtures/"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-case-conflict
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: fix-encoding-pragma
+        args: [--remove]
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.2.1"
+    hooks:
+      - id: ruff
+        args:
+          - --fix-only
+          - --target-version=py39
+
+  - repo: https://github.com/python/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        args:
+          - "--config=pyproject.toml"
+          - --target-version=py39
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args:
+          - --profile
+          - black
+          - --filter-files
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        files: ^pyqgisgmsher/.*\.py$
+        additional_dependencies: ["flake8-qgis<2"]
+        args:
+          [
+            "--config=pyproject.toml",
+            "--select=E9,F63,F7,F82,QGS101,QGS102,QGS103,QGS104,QGS106",
+          ]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "davidanson.vscode-markdownlint",
+    "ms-python.black-formatter",
+    "ms-python.flake8",
+    "ms-python.isort",
+
+    "ms-python.python",
+    "njpwerner.autodocstring",
+    "redhat.vscode-yaml",
+    "zhoufeng.pyqt-integration"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,44 @@
+{
+    // Editor
+    "editor.bracketPairColorization.enabled": true,
+    "editor.guides.bracketPairs": "active",
+    "files.associations": {
+        "./requirements/*.txt": "pip-requirements",
+        "metadata.txt": "ini",
+        "**/*.model3": "xml",
+        "**/*.ts": "xml",
+        "**/*.ui": "xml"
+    },
+    // Python
+    "python.analysis.autoFormatStrings": false, // breaking PyQt translation
+    "python.analysis.typeCheckingMode": "off",
+    "python.terminal.activateEnvInCurrentTerminal": true,
+    "python.terminal.activateEnvironment": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+        },
+        "editor.rulers": [
+            120
+        ],
+        "editor.wordWrapColumn": 120,
+    },
+    // Linter
+
+    "flake8.args": [
+        "--config=pyproject.toml",
+        "--verbose"
+    ],
+
+    // Tests
+    "python.testing.unittestEnabled": true,
+    "python.testing.pytestEnabled": true,
+    // Extensions
+    "autoDocstring.docstringFormat": "sphinx",
+    "black-formatter.args": [
+        "--config",
+        "pyproject.toml"
+    ]
+}

--- a/LAStools/lastools/core/algo/lastools_algorithm.py
+++ b/LAStools/lastools/core/algo/lastools_algorithm.py
@@ -66,6 +66,12 @@ class LastoolsAlgorithm(QgsProcessingAlgorithm):
     APPLY_FILE_SOURCE_ID = "APPLY_FILE_SOURCE_ID"
     STEP = "STEP"
 
+    # Generic options that should be reimplemented in child classes
+    TOOL_NAME = "Generic"
+    LASTOOL = "generic"
+    LICENSE = "o"
+    LASGROUP = 1
+
     FILTER_RETURN_CLASS_FLAGS1 = "FILTER_RETURN_CLASS_FLAGS1"
     FILTER_RETURN_CLASS_FLAGS2 = "FILTER_RETURN_CLASS_FLAGS2"
     FILTER_RETURN_CLASS_FLAGS3 = "FILTER_RETURN_CLASS_FLAGS3"
@@ -459,6 +465,16 @@ class LastoolsAlgorithm(QgsProcessingAlgorithm):
             return "64"
         else:
             return ""
+
+    def get_command(self, parameters, context):
+        wine_path, lastools_path = LastoolsUtils.lastools_path()
+        las_command = (
+            lastools_path / "bin" / (self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext())
+        ).as_posix()
+        if wine_path is None:  # Windows
+            return f'"{las_command}"'
+        else:  # Linux
+            return f'"{(wine_path / "wine").as_posix()}" "{las_command}"'
 
     def add_parameters_verbose_gui(self):
         self.addParameter(QgsProcessingParameterBoolean(self.VERBOSE, "verbose", False))

--- a/LAStools/lastools/core/algo/lastools_algorithm.py
+++ b/LAStools/lastools/core/algo/lastools_algorithm.py
@@ -451,8 +451,7 @@ class LastoolsAlgorithm(QgsProcessingAlgorithm):
 
     @staticmethod
     def check_before_opening_parameters_dialog():
-        path = LastoolsUtils.lastools_path()
-        if path == "":
+        if not LastoolsUtils.validate_config_paths():
             return "LAStools folder is not configured. Please configure it before running LAStools algorithms."
 
     def cpu64(self, parameters, context):

--- a/LAStools/lastools/core/algo/lastools_algorithm.py
+++ b/LAStools/lastools/core/algo/lastools_algorithm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lastools_algorithm.py
@@ -21,18 +19,18 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-from PyQt5.QtGui import QIcon
 from qgis.core import (
     QgsProcessingAlgorithm,
     QgsProcessingParameterBoolean,
-    QgsProcessingParameterNumber,
-    QgsProcessingParameterString,
     QgsProcessingParameterEnum,
     QgsProcessingParameterFile,
     QgsProcessingParameterFileDestination,
     QgsProcessingParameterFolderDestination,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterString,
 )
 from qgis.PyQt.QtCore import QCoreApplication
+
 from ..utils import LastoolsUtils
 
 

--- a/LAStools/lastools/core/classification_filtering/__init__.py
+++ b/LAStools/lastools/core/classification_filtering/__init__.py
@@ -1,11 +1,15 @@
+from .lasclassify import LasClassify, LasClassifyPro
 from .lasground import LasGround, LasGroundPro
 from .lasground_new import LasGroundNew, LasGroundProNew
-from .lasclassify import LasClassify, LasClassifyPro
 from .lasthin import LasThin, LasThinPro
 
 __all__ = [
-    LasGround, LasGroundPro,
-    LasGroundNew, LasGroundProNew,
-    LasClassify, LasClassifyPro,
-    LasThin, LasThinPro,
+    LasGround,
+    LasGroundPro,
+    LasGroundNew,
+    LasGroundProNew,
+    LasClassify,
+    LasClassifyPro,
+    LasThin,
+    LasThinPro,
 ]

--- a/LAStools/lastools/core/classification_filtering/lasclassify.py
+++ b/LAStools/lastools/core/classification_filtering/lasclassify.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -43,13 +42,7 @@ class LasClassify(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
@@ -108,13 +101,7 @@ class LasClassifyPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)

--- a/LAStools/lastools/core/classification_filtering/lasclassify.py
+++ b/LAStools/lastools/core/classification_filtering/lasclassify.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasclassify.py
@@ -23,10 +21,10 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasClassify(LastoolsAlgorithm):

--- a/LAStools/lastools/core/classification_filtering/lasground.py
+++ b/LAStools/lastools/core/classification_filtering/lasground.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
 from qgis.PyQt.QtGui import QIcon
@@ -59,13 +58,7 @@ class LasGround(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_horizontal_and_vertical_feet_commands(parameters, context, commands)
@@ -147,13 +140,7 @@ class LasGroundPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_horizontal_and_vertical_feet_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.NO_BULGE, context):

--- a/LAStools/lastools/core/classification_filtering/lasground.py
+++ b/LAStools/lastools/core/classification_filtering/lasground.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasground.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasGround(LastoolsAlgorithm):

--- a/LAStools/lastools/core/classification_filtering/lasground_new.py
+++ b/LAStools/lastools/core/classification_filtering/lasground_new.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -109,13 +108,7 @@ class LasGroundNew(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_horizontal_and_vertical_feet_commands(parameters, context, commands)
@@ -255,13 +248,7 @@ class LasGroundProNew(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_horizontal_and_vertical_feet_commands(parameters, context, commands)

--- a/LAStools/lastools/core/classification_filtering/lasground_new.py
+++ b/LAStools/lastools/core/classification_filtering/lasground_new.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasground_new.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasGroundNew(LastoolsAlgorithm):

--- a/LAStools/lastools/core/classification_filtering/lasthin.py
+++ b/LAStools/lastools/core/classification_filtering/lasthin.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasthin.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasThin(LastoolsAlgorithm):

--- a/LAStools/lastools/core/classification_filtering/lasthin.py
+++ b/LAStools/lastools/core/classification_filtering/lasthin.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -81,13 +80,7 @@ class LasThin(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)
@@ -202,13 +195,7 @@ class LasThinPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)

--- a/LAStools/lastools/core/data_compression/__init__.py
+++ b/LAStools/lastools/core/data_compression/__init__.py
@@ -1,5 +1,6 @@
 from .laszip import LasZip, LasZipPro
 
 __all__ = [
-    LasZip, LasZipPro
+    LasZip,
+    LasZipPro,
 ]

--- a/LAStools/lastools/core/data_compression/laszip.py
+++ b/LAStools/lastools/core/data_compression/laszip.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean
 from qgis.PyQt.QtGui import QIcon
@@ -47,13 +46,7 @@ class LasZip(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.REPORT_SIZE, context):
@@ -118,13 +111,7 @@ class LasZipPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.REPORT_SIZE, context):

--- a/LAStools/lastools/core/data_compression/laszip.py
+++ b/LAStools/lastools/core/data_compression/laszip.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     laszip.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterBoolean
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasZip(LastoolsAlgorithm):

--- a/LAStools/lastools/core/data_convert/__init__.py
+++ b/LAStools/lastools/core/data_convert/__init__.py
@@ -1,16 +1,16 @@
+from .e572las import e572las
 from .las2las import (
     Las2LasFilter,
     Las2LasProFilter,
     Las2LasProject,
     Las2LasProProject,
-    Las2LasTransform,
     Las2LasProTransform,
+    Las2LasTransform,
 )
-from .las2txt import Las2txt, Las2txtPro
-from .txt2las import Txt2Las, Txt2LasPro
 from .las2shp import Las2Shp
+from .las2txt import Las2txt, Las2txtPro
 from .shp2las import Shp2Las
-from .e572las import e572las
+from .txt2las import Txt2Las, Txt2LasPro
 
 __all__ = [
     Las2txt,

--- a/LAStools/lastools/core/data_convert/e572las.py
+++ b/LAStools/lastools/core/data_convert/e572las.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(C) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -67,13 +66,7 @@ class e572las(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_generic_input_commands(parameters, context, commands, "-i")
 
         scale_factor_xy = self.parameterAsDouble(parameters, self.SCALE_FACTOR_XY, context)

--- a/LAStools/lastools/core/data_convert/e572las.py
+++ b/LAStools/lastools/core/data_convert/e572las.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     e572las.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterString, QgsProcessingParameterBoolean
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class e572las(LastoolsAlgorithm):

--- a/LAStools/lastools/core/data_convert/las2las.py
+++ b/LAStools/lastools/core/data_convert/las2las.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las2las.py
@@ -23,12 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterString, QgsProcessingParameterNumber
-
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Las2LasFilter(LastoolsAlgorithm):
@@ -181,7 +178,7 @@ class Las2LasProject(LastoolsAlgorithm):
                 source_sp_code = self.parameterAsInt(parameters, self.SOURCE_SP, context)
                 if source_sp_code != 0:
                     commands.append("-" + self.PROJECTIONS[source_projection])
-                    commands.append(STATE_PLANES[source_sp_code])
+                    commands.append(self.STATE_PLANES[source_sp_code])
             else:
                 commands.append("-" + self.PROJECTIONS[source_projection])
         target_projection = self.parameterAsInt(parameters, self.TARGET_PROJECTION, context)
@@ -203,7 +200,7 @@ class Las2LasProject(LastoolsAlgorithm):
                 target_sp_code = self.parameterAsInt(parameters, self.TARGET_SP, context)
                 if target_sp_code != 0:
                     commands.append("-target_" + self.PROJECTIONS[target_projection])
-                    commands.append(STATE_PLANES[target_sp_code])
+                    commands.append(self.STATE_PLANES[target_sp_code])
             else:
                 commands.append("-target_" + self.PROJECTIONS[target_projection])
         self.add_parameters_additional_commands(parameters, context, commands)
@@ -501,7 +498,7 @@ class Las2LasProProject(LastoolsAlgorithm):
                 source_sp_code = self.parameterAsInt(parameters, self.SOURCE_SP, context)
                 if source_sp_code != 0:
                     commands.append("-" + self.PROJECTIONS[source_projection])
-                    commands.append(STATE_PLANES[source_sp_code])
+                    commands.append(self.STATE_PLANES[source_sp_code])
             else:
                 commands.append("-" + self.PROJECTIONS[source_projection])
         target_projection = self.parameterAsInt(parameters, self.TARGET_PROJECTION, context)
@@ -523,7 +520,7 @@ class Las2LasProProject(LastoolsAlgorithm):
                 target_sp_code = self.parameterAsInt(parameters, self.TARGET_SP, context)
                 if target_sp_code != 0:
                     commands.append("-target_" + self.PROJECTIONS[target_projection])
-                    commands.append(STATE_PLANES[target_sp_code])
+                    commands.append(self.STATE_PLANES[target_sp_code])
             else:
                 commands.append("-target_" + self.PROJECTIONS[target_projection])
         self.add_parameters_additional_commands(parameters, context, commands)

--- a/LAStools/lastools/core/data_convert/las2las.py
+++ b/LAStools/lastools/core/data_convert/las2las.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber, QgsProcessingParameterString
 from qgis.PyQt.QtGui import QIcon
@@ -45,13 +44,7 @@ class Las2LasFilter(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         self.add_parameters_filter2_return_class_flags_commands(parameters, context, commands)
@@ -151,13 +144,7 @@ class Las2LasProject(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         source_projection = self.parameterAsInt(parameters, self.SOURCE_PROJECTION, context)
         if source_projection != 0:
@@ -285,13 +272,7 @@ class Las2LasTransform(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_transform1_coordinate_commands(parameters, context, commands)
         self.add_parameters_transform2_coordinate_commands(parameters, context, commands)
@@ -359,13 +340,7 @@ class Las2LasProFilter(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui(False)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         self.add_parameters_filter2_return_class_flags_commands(parameters, context, commands)
@@ -471,13 +446,7 @@ class Las2LasProProject(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui(False)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         source_projection = self.parameterAsInt(parameters, self.SOURCE_PROJECTION, context)
         if source_projection != 0:
@@ -612,13 +581,7 @@ class Las2LasProTransform(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_transform1_coordinate_commands(parameters, context, commands)
         self.add_parameters_transform2_coordinate_commands(parameters, context, commands)

--- a/LAStools/lastools/core/data_convert/las2shp.py
+++ b/LAStools/lastools/core/data_convert/las2shp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las2shp.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Las2Shp(LastoolsAlgorithm):

--- a/LAStools/lastools/core/data_convert/las2shp.py
+++ b/LAStools/lastools/core/data_convert/las2shp.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -55,13 +54,7 @@ class Las2Shp(LastoolsAlgorithm):
         self.add_parameters_generic_output_gui("Output SHP file", "shp", True)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.POINT_Z, context):
             commands.append("-single_points")

--- a/LAStools/lastools/core/data_convert/las2txt.py
+++ b/LAStools/lastools/core/data_convert/las2txt.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterString
 from qgis.PyQt.QtGui import QIcon
@@ -45,13 +44,7 @@ class Las2txt(LastoolsAlgorithm):
         self.add_parameters_generic_output_gui("Output ASCII file", "txt", False)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         parse = self.parameterAsString(parameters, self.PARSE, context)
         if parse != "xyz":
@@ -113,13 +106,7 @@ class Las2txtPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         parse = self.parameterAsString(parameters, self.PARSE, context)
         if parse != "xyz":

--- a/LAStools/lastools/core/data_convert/las2txt.py
+++ b/LAStools/lastools/core/data_convert/las2txt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las2txt.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterString, QgsProcessingParameterBoolean
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Las2txt(LastoolsAlgorithm):

--- a/LAStools/lastools/core/data_convert/shp2las.py
+++ b/LAStools/lastools/core/data_convert/shp2las.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -63,13 +62,7 @@ class Shp2Las(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_generic_input_commands(parameters, context, commands, "-i")
         scale_factor_xy = self.parameterAsDouble(parameters, self.SCALE_FACTOR_XY, context)
         scale_factor_z = self.parameterAsInt(parameters, self.SCALE_FACTOR_Z, context)

--- a/LAStools/lastools/core/data_convert/shp2las.py
+++ b/LAStools/lastools/core/data_convert/shp2las.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     shp2las.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Shp2Las(LastoolsAlgorithm):

--- a/LAStools/lastools/core/data_convert/txt2las.py
+++ b/LAStools/lastools/core/data_convert/txt2las.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber, QgsProcessingParameterString
 from qgis.PyQt.QtGui import QIcon
@@ -79,13 +78,7 @@ class Txt2Las(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_generic_input_commands(parameters, context, commands, "-i")
         parse_string = self.parameterAsString(parameters, self.PARSE, context)
         if parse_string != "xyz":
@@ -216,13 +209,7 @@ class Txt2LasPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         # TODO: check the output and use f string
         self.add_parameters_generic_input_folder_commands(parameters, context, commands)
         parse_string = self.parameterAsString(parameters, self.PARSE, context)

--- a/LAStools/lastools/core/data_convert/txt2las.py
+++ b/LAStools/lastools/core/data_convert/txt2las.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     txt2las.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterString, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Txt2Las(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/__init__.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/__init__.py
@@ -1,12 +1,12 @@
-from .las2dem import Las2Dem, Las2DemPro
-from .las2iso import Las2Iso
-from .lasplanes import LasPlanes
-from .lasvoxel import LasVoxel
-from .lasgrid import LasGrid, LasGridPro
-from .lasheight import LasHeight, LasHeightClassify, LasHeightPro, LasHeightProClassify
-from .lascanopy import LasCanopy, LasCanopyPro
 from .blast2dem import Blast2Dem, Blast2DemPro
 from .blast2iso import Blast2Iso, Blast2IsoPro
+from .las2dem import Las2Dem, Las2DemPro
+from .las2iso import Las2Iso
+from .lascanopy import LasCanopy, LasCanopyPro
+from .lasgrid import LasGrid, LasGridPro
+from .lasheight import LasHeight, LasHeightClassify, LasHeightPro, LasHeightProClassify
+from .lasplanes import LasPlanes
+from .lasvoxel import LasVoxel
 
 __all__ = [
     Las2Dem,

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2dem.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2dem.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
 from qgis.PyQt.QtGui import QIcon
@@ -53,13 +52,7 @@ class Blast2Dem(LastoolsAlgorithm):
         self.add_parameters_raster_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         self.add_parameters_step_commands(parameters, context, commands)
@@ -135,13 +128,7 @@ class Blast2DemPro(LastoolsAlgorithm):
         self.add_parameters_raster_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_point_input_merged_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2dem.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2dem.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     blast2dem.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Blast2Dem(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2iso.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2iso.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     blast2iso.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Blast2Iso(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2iso.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/blast2iso.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -95,13 +94,7 @@ class Blast2Iso(LastoolsAlgorithm):
         self.add_parameters_vector_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         smooth = self.parameterAsInt(parameters, self.SMOOTH, context)
         if smooth != 0:
@@ -228,13 +221,7 @@ class Blast2IsoPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_point_input_merged_commands(parameters, context, commands)
         smooth = self.parameterAsInt(parameters, self.SMOOTH, context)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2dem.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2dem.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
 from qgis.PyQt.QtGui import QIcon
@@ -53,13 +52,7 @@ class Las2Dem(LastoolsAlgorithm):
         self.add_parameters_raster_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         self.add_parameters_step_commands(parameters, context, commands)
@@ -134,13 +127,7 @@ class Las2DemPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         self.add_parameters_step_commands(parameters, context, commands)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2dem.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2dem.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las2dem.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterBoolean
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Las2Dem(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2iso.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2iso.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -95,13 +94,7 @@ class Las2Iso(LastoolsAlgorithm):
         self.add_parameters_vector_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         smooth = self.parameterAsInt(parameters, self.SMOOTH, context)
         if smooth != 0:

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2iso.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2iso.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las2iso.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Las2Iso(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2tin.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2tin.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from lastools.core.algo.lastools_algorithm import LastoolsAlgorithm
 from lastools.core.utils.utils import LastoolsUtils
@@ -36,13 +35,7 @@ class las2tin(LastoolsAlgorithm):
         self.add_parameters_additional_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2tin.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/las2tin.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las2tin.py
@@ -22,8 +20,9 @@ __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
-from lastools.core.utils.utils import LastoolsUtils
+
 from lastools.core.algo.lastools_algorithm import LastoolsAlgorithm
+from lastools.core.utils.utils import LastoolsUtils
 
 
 class las2tin(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lascanopy.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lascanopy.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import (
     QgsProcessingParameterBoolean,
@@ -125,13 +124,7 @@ class LasCanopy(LastoolsAlgorithm):
         self.add_parameters_raster_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         plot_size = self.parameterAsDouble(parameters, self.PLOT_SIZE, context)
         if plot_size != 20.0:
@@ -314,13 +307,7 @@ class LasCanopyPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_point_input_merged_commands(parameters, context, commands)
         plot_size = self.parameterAsDouble(parameters, self.PLOT_SIZE, context)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lascanopy.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lascanopy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lascanopy.py
@@ -23,16 +21,16 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import (
     QgsProcessingParameterBoolean,
     QgsProcessingParameterEnum,
     QgsProcessingParameterNumber,
     QgsProcessingParameterString,
 )
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasCanopy(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasgrid.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasgrid.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasgrid.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterBoolean
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasGrid(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasgrid.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasgrid.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
 from qgis.PyQt.QtGui import QIcon
@@ -53,13 +52,7 @@ class LasGrid(LastoolsAlgorithm):
         self.add_parameters_raster_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         self.add_parameters_step_commands(parameters, context, commands)
@@ -136,13 +129,7 @@ class LasGridPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_point_input_merged_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasheight.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasheight.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasheight.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasHeight(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasheight.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasheight.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -61,13 +60,7 @@ class LasHeight(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)
@@ -238,13 +231,7 @@ class LasHeightClassify(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)
@@ -343,13 +330,7 @@ class LasHeightPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)
@@ -526,13 +507,7 @@ class LasHeightProClassify(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasplanes.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasplanes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasplanes.py
@@ -23,11 +21,10 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasPlanes(LastoolsAlgorithm):

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasplanes.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasplanes.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -40,13 +39,7 @@ class LasPlanes(LastoolsAlgorithm):
         self.add_parameters_vector_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_additional_commands(parameters, context, commands)
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasvoxel.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasvoxel.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -93,13 +92,7 @@ class LasVoxel(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         step = self.parameterAsDouble(parameters, self.ARG_STEP, context)
         commands.append("-step")

--- a/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasvoxel.py
+++ b/LAStools/lastools/core/dsm_dtm_generation_prodctions/lasvoxel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasvoxel.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterBoolean
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasVoxel(LastoolsAlgorithm):

--- a/LAStools/lastools/core/pipelines/__init__.py
+++ b/LAStools/lastools/core/pipelines/__init__.py
@@ -1,15 +1,24 @@
 from .flightlines2chm import FlightLinesToCHMFirstReturn, FlightLinesToCHMHighestReturn, FlightLinesToCHMSpikeFree
 from .flightlines2dtmdsm import FlightLinesToDTMandDSMFirstReturn, FlightLinesToDTMandDSMSpikeFree
 from .flightlines2mergedchm import (
-    FlightLinesToMergedCHMFirstReturn, FlightLinesToMergedCHMHighestReturn, FlightLinesToMergedCHMPitFree,
-    FlightLinesToMergedCHMSpikeFree
+    FlightLinesToMergedCHMFirstReturn,
+    FlightLinesToMergedCHMHighestReturn,
+    FlightLinesToMergedCHMPitFree,
+    FlightLinesToMergedCHMSpikeFree,
 )
 from .hugefile import HugeFileClassify, HugeFileGroundClassify, HugeFileNormalize
 
 __all__ = [
-    FlightLinesToCHMFirstReturn, FlightLinesToCHMHighestReturn, FlightLinesToCHMSpikeFree,
-    FlightLinesToDTMandDSMFirstReturn, FlightLinesToDTMandDSMSpikeFree,
-    FlightLinesToMergedCHMFirstReturn, FlightLinesToMergedCHMHighestReturn, FlightLinesToMergedCHMPitFree,
+    FlightLinesToCHMFirstReturn,
+    FlightLinesToCHMHighestReturn,
+    FlightLinesToCHMSpikeFree,
+    FlightLinesToDTMandDSMFirstReturn,
+    FlightLinesToDTMandDSMSpikeFree,
+    FlightLinesToMergedCHMFirstReturn,
+    FlightLinesToMergedCHMHighestReturn,
+    FlightLinesToMergedCHMPitFree,
     FlightLinesToMergedCHMSpikeFree,
-    HugeFileClassify, HugeFileGroundClassify, HugeFileNormalize
+    HugeFileClassify,
+    HugeFileGroundClassify,
+    HugeFileNormalize,
 ]

--- a/LAStools/lastools/core/pipelines/flightlines2chm.py
+++ b/LAStools/lastools/core/pipelines/flightlines2chm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     flightlines2chm.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2024, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterEnum, QgsProcessingParameterString
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class FlightLinesToCHMFirstReturn(LastoolsAlgorithm):

--- a/LAStools/lastools/core/pipelines/flightlines2dtmdsm.py
+++ b/LAStools/lastools/core/pipelines/flightlines2dtmdsm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     flightlines2dtmdsm.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2024, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterEnum, QgsProcessingParameterString
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class FlightLinesToDTMandDSMFirstReturn(LastoolsAlgorithm):

--- a/LAStools/lastools/core/pipelines/flightlines2mergedchm.py
+++ b/LAStools/lastools/core/pipelines/flightlines2mergedchm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     flightlines2mergedchm.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2024, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class FlightLinesToMergedCHMFirstReturn(LastoolsAlgorithm):

--- a/LAStools/lastools/core/pipelines/hugefile.py
+++ b/LAStools/lastools/core/pipelines/hugefile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     hugefile.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2024, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class HugeFileClassify(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/__init__.py
+++ b/LAStools/lastools/core/processing/__init__.py
@@ -1,7 +1,8 @@
 """
 Importing all the layers belonging to processing toolbox
 """
-from .las3dpoly import Las3dPolyRadialDistance, Las3dPolyHorizontalVerticalDistance
+
+from .las3dpoly import Las3dPolyHorizontalVerticalDistance, Las3dPolyRadialDistance
 from .lasboundary import LasBoundary, LasBoundaryPro
 from .lasclip import LasClip
 from .lascopy import LasCopy

--- a/LAStools/lastools/core/processing/las3dpoly.py
+++ b/LAStools/lastools/core/processing/las3dpoly.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las3dpoly.py
@@ -24,18 +22,16 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 import os
 
 from qgis.core import (
-    QgsProcessingParameterNumber,
-    QgsProcessingParameterDefinition,
     QgsProcessingParameterBoolean,
-    QgsProcessingParameterString,
-    QgsProcessingParameterFile,
-    QgsProcessingParameterFileDestination,
+    QgsProcessingParameterDefinition,
     QgsProcessingParameterEnum,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterNumber,
 )
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
-from PyQt5.QtGui import QIcon
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class Las3dPolyRadialDistance(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasboundary.py
+++ b/LAStools/lastools/core/processing/lasboundary.py
@@ -23,7 +23,6 @@ __author__ = "Victor Olaya"
 __date__ = "August 2012"
 __copyright__ = "(C) 2012, Victor Olaya"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -61,13 +60,7 @@ class LasBoundary(LastoolsAlgorithm):
         self.add_parameters_vector_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         mode = self.parameterAsInt(parameters, self.MODE, context)
@@ -155,13 +148,7 @@ class LasBoundaryPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
         mode = self.parameterAsInt(parameters, self.MODE, context)

--- a/LAStools/lastools/core/processing/lasboundary.py
+++ b/LAStools/lastools/core/processing/lasboundary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasboundary.py
@@ -27,13 +25,11 @@ __copyright__ = "(C) 2012, Victor Olaya"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterEnum
-from qgis.core import QgsProcessingParameterBoolean
-from qgis.core import QgsProcessingParameterNumber
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasBoundary(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasclip.py
+++ b/LAStools/lastools/core/processing/lasclip.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasclip.py
@@ -27,13 +25,11 @@ __copyright__ = "(C) 2012, Victor Olaya"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean
-from qgis.core import QgsProcessingParameterNumber
-from qgis.core import QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasClip(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasclip.py
+++ b/LAStools/lastools/core/processing/lasclip.py
@@ -23,7 +23,6 @@ __author__ = "Victor Olaya"
 __date__ = "August 2012"
 __copyright__ = "(C) 2012, Victor Olaya"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -59,13 +58,7 @@ class LasClip(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_generic_input_commands(parameters, context, commands, "-poly")
         if self.parameterAsBool(parameters, self.INTERIOR, context):

--- a/LAStools/lastools/core/processing/lascopy.py
+++ b/LAStools/lastools/core/processing/lascopy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     self.py
@@ -23,14 +21,11 @@ __copyright__ = "(C) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import (
-    QgsProcessingParameterBoolean,
-    QgsProcessingParameterNumber,
-)  # , QgsProcessingParameterString, QgsProcessingParameterEnum,
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasCopy(LastoolsAlgorithm):
@@ -106,7 +101,13 @@ class LasCopy(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [os.path.join(LastoolsUtils.lastools_path(), "bin", self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext())]
+        commands = [
+            os.path.join(
+                LastoolsUtils.lastools_path(),
+                "bin",
+                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
+            )
+        ]
         self.add_parameters_point_input_commands(parameters, context, commands)
 
         if self.parameterAsBool(parameters, self.MATCH_GPS_TIME, context):

--- a/LAStools/lastools/core/processing/lascopy.py
+++ b/LAStools/lastools/core/processing/lascopy.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(C) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -101,13 +100,7 @@ class LasCopy(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
 
         if self.parameterAsBool(parameters, self.MATCH_GPS_TIME, context):

--- a/LAStools/lastools/core/processing/lasdiff.py
+++ b/LAStools/lastools/core/processing/lasdiff.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasdiff.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasDiff(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasdiff.py
+++ b/LAStools/lastools/core/processing/lasdiff.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum
 from qgis.PyQt.QtGui import QIcon
@@ -57,13 +56,7 @@ class LasDiff(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_generic_input_commands(parameters, context, commands, "-i")
         shutup = self.parameterAsInt(parameters, self.SHUTUP, context)

--- a/LAStools/lastools/core/processing/lasdistance.py
+++ b/LAStools/lastools/core/processing/lasdistance.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import (
     QgsProcessingParameterBoolean,
@@ -141,13 +140,7 @@ class LasDistance(LastoolsAlgorithm):
 
     def processAlgorithm(self, parameters, context, feedback):
         # calling the specific .exe files from source of software
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         # append poly
         commands.append(f"-poly {parameters['INPUT_POLYLINE_PATH']}")

--- a/LAStools/lastools/core/processing/lasdistance.py
+++ b/LAStools/lastools/core/processing/lasdistance.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasdistance.py
@@ -24,18 +22,16 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 import os
 
 from qgis.core import (
-    QgsProcessingParameterNumber,
-    QgsProcessingParameterDefinition,
     QgsProcessingParameterBoolean,
-    QgsProcessingParameterString,
-    QgsProcessingParameterFile,
-    QgsProcessingParameterFileDestination,
+    QgsProcessingParameterDefinition,
     QgsProcessingParameterEnum,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterNumber,
 )
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
-from PyQt5.QtGui import QIcon
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasDistance(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasduplicate.py
+++ b/LAStools/lastools/core/processing/lasduplicate.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -74,13 +73,7 @@ class LasDuplicate(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.LOWEST_Z, context):
             commands.append("-lowest_z")
@@ -179,13 +172,7 @@ class LasDuplicatePro(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.LOWEST_Z, context):

--- a/LAStools/lastools/core/processing/lasduplicate.py
+++ b/LAStools/lastools/core/processing/lasduplicate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasduplicate.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasDuplicate(LastoolsAlgorithm):
@@ -94,7 +92,7 @@ class LasDuplicate(LastoolsAlgorithm):
             commands.append("-single_returns")
         if self.parameterAsBool(parameters, self.NEARBY, context):
             commands.append("-nearby")
-            commands.append(unicode(self.parameterAsDouble(parameters, self.NEARBY_TOLERANCE, context)))
+            commands.append(str(self.parameterAsDouble(parameters, self.NEARBY_TOLERANCE, context)))
         if self.parameterAsBool(parameters, self.RECORD_REMOVED, context):
             commands.append("-record_removed")
         self.add_parameters_additional_commands(parameters, context, commands)
@@ -200,7 +198,7 @@ class LasDuplicatePro(LastoolsAlgorithm):
             commands.append("-single_returns")
         if self.parameterAsBool(parameters, self.NEARBY, context):
             commands.append("-nearby")
-            commands.append(unicode(self.parameterAsDouble(parameters, self.NEARBY_TOLERANCE, context)))
+            commands.append(str(self.parameterAsDouble(parameters, self.NEARBY_TOLERANCE, context)))
         if self.parameterAsBool(parameters, self.RECORD_REMOVED, context):
             commands.append("-record_removed")
         self.add_parameters_output_directory_commands(parameters, context, commands)

--- a/LAStools/lastools/core/processing/lasindex.py
+++ b/LAStools/lastools/core/processing/lasindex.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasindex.py
@@ -22,11 +20,12 @@ __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
+from qgis.core import QgsProcessingParameterBoolean
+from qgis.PyQt.QtGui import QIcon
+
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasIndex(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasindex.py
+++ b/LAStools/lastools/core/processing/lasindex.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean
 from qgis.PyQt.QtGui import QIcon
@@ -48,13 +47,7 @@ class LasIndex(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.APPEND_LAX, context):
             commands.append("-append")
@@ -118,13 +111,7 @@ class LasIndexPro(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.APPEND_LAX, context):
             commands.append("-append")

--- a/LAStools/lastools/core/processing/lasintensity.py
+++ b/LAStools/lastools/core/processing/lasintensity.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     las3dpoly.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterFileDestination, QgsProcessingParameterString
+from qgis.core import QgsProcessingParameterFileDestination, QgsProcessingParameterNumber, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasIntensity(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasmerge.py
+++ b/LAStools/lastools/core/processing/lasmerge.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterFile
 from qgis.PyQt.QtGui import QIcon
@@ -67,13 +66,7 @@ class LasMerge(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         file2 = self.parameterAsString(parameters, self.FILE2, context)
         if file2 != "":
@@ -151,13 +144,7 @@ class LasMergePro(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_files_are_flightlines_commands(parameters, context, commands)
         self.add_parameters_apply_file_source_id_commands(parameters, context, commands)

--- a/LAStools/lastools/core/processing/lasmerge.py
+++ b/LAStools/lastools/core/processing/lasmerge.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasmerge.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterFile
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasMerge(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasnoise.py
+++ b/LAStools/lastools/core/processing/lasnoise.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -87,13 +86,7 @@ class LasNoise(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)
@@ -210,13 +203,7 @@ class LasNoisePro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_ignore_class1_commands(parameters, context, commands)
         self.add_parameters_ignore_class2_commands(parameters, context, commands)

--- a/LAStools/lastools/core/processing/lasnoise.py
+++ b/LAStools/lastools/core/processing/lasnoise.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasnoise.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasNoise(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasoverage.py
+++ b/LAStools/lastools/core/processing/lasoverage.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -57,13 +56,7 @@ class LasOverage(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_horizontal_feet_commands(parameters, context, commands)
         self.add_parameters_files_are_flightlines_commands(parameters, context, commands)
@@ -143,13 +136,7 @@ class LasOveragePro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_horizontal_feet_commands(parameters, context, commands)
         self.add_parameters_files_are_flightlines_commands(parameters, context, commands)

--- a/LAStools/lastools/core/processing/lasoverage.py
+++ b/LAStools/lastools/core/processing/lasoverage.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasoverage.py
@@ -23,12 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber
-from qgis.core import QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasOverage(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lasprecision.py
+++ b/LAStools/lastools/core/processing/lasprecision.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(C) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -40,13 +39,7 @@ class LasPrecision(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_additional_commands(parameters, context, commands)

--- a/LAStools/lastools/core/processing/lasprecision.py
+++ b/LAStools/lastools/core/processing/lasprecision.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasprecision.py
@@ -23,11 +21,10 @@ __copyright__ = "(C) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterString, QgsProcessingParameterBoolean, QgsProcessingParameterEnum
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasPrecision(LastoolsAlgorithm):
@@ -43,7 +40,13 @@ class LasPrecision(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [os.path.join(LastoolsUtils.lastools_path(), "bin", self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext())]
+        commands = [
+            os.path.join(
+                LastoolsUtils.lastools_path(),
+                "bin",
+                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
+            )
+        ]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_additional_commands(parameters, context, commands)

--- a/LAStools/lastools/core/processing/lassort.py
+++ b/LAStools/lastools/core/processing/lassort.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean
 from qgis.PyQt.QtGui import QIcon
@@ -47,13 +46,7 @@ class LasSort(LastoolsAlgorithm):
         self.add_parameters_additional_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.BY_GPS_TIME, context):
@@ -120,13 +113,7 @@ class LasSortPro(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.BY_GPS_TIME, context):

--- a/LAStools/lastools/core/processing/lassort.py
+++ b/LAStools/lastools/core/processing/lassort.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lassortpy
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterFile, QgsProcessingParameterBoolean
+from qgis.core import QgsProcessingParameterBoolean
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasSort(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lassplit.py
+++ b/LAStools/lastools/core/processing/lassplit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lassplit.py
@@ -23,12 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber
-from qgis.core import QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasSplit(LastoolsAlgorithm):

--- a/LAStools/lastools/core/processing/lassplit.py
+++ b/LAStools/lastools/core/processing/lassplit.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -80,13 +79,7 @@ class LasSplit(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         digits = self.parameterAsInt(parameters, self.DIGITS, context)
         if digits != 5:

--- a/LAStools/lastools/core/processing/lastile.py
+++ b/LAStools/lastools/core/processing/lastile.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterString
 from qgis.PyQt.QtGui import QIcon
@@ -71,13 +70,7 @@ class LasTile(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         tile_size = self.parameterAsInt(parameters, self.TILE_SIZE, context)
         commands.append("-tile_size")
@@ -180,13 +173,7 @@ class LasTilePro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_files_are_flightlines_commands(parameters, context, commands)
         self.add_parameters_apply_file_source_id_commands(parameters, context, commands)

--- a/LAStools/lastools/core/processing/lastile.py
+++ b/LAStools/lastools/core/processing/lastile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lastile.py
@@ -23,12 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterString
-from qgis.core import QgsProcessingParameterNumber
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasTile(LastoolsAlgorithm):

--- a/LAStools/lastools/core/publishing/__init__.py
+++ b/LAStools/lastools/core/publishing/__init__.py
@@ -1,5 +1,6 @@
 from .laspublish import LasPublish, LasPublishPro
 
 __all__ = [
-    LasPublish, LasPublishPro
+    LasPublish,
+    LasPublishPro,
 ]

--- a/LAStools/lastools/core/publishing/laspublish.py
+++ b/LAStools/lastools/core/publishing/laspublish.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     self.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2024, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterBoolean, QgsProcessingParameterString
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasPublish(LastoolsAlgorithm):
@@ -76,7 +74,13 @@ class LasPublish(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui(optional_value=False)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [os.path.join(LastoolsUtils.lastools_path(), "bin", self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext())]
+        commands = [
+            os.path.join(
+                LastoolsUtils.lastools_path(),
+                "bin",
+                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
+            )
+        ]
         self.add_parameters_verbose_gui_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         mode = self.parameterAsInt(parameters, self.MODE, context)
@@ -199,7 +203,13 @@ class LasPublishPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui(optional_value=False)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [os.path.join(LastoolsUtils.lastools_path(), "bin", self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext())]
+        commands = [
+            os.path.join(
+                LastoolsUtils.lastools_path(),
+                "bin",
+                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
+            )
+        ]
         self.add_parameters_verbose_gui_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         mode = self.parameterAsInt(parameters, LasPublishPro.MODE, context)

--- a/LAStools/lastools/core/publishing/laspublish.py
+++ b/LAStools/lastools/core/publishing/laspublish.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "March 2024"
 __copyright__ = "(C) 2024, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterString
 from qgis.PyQt.QtGui import QIcon
@@ -74,13 +73,7 @@ class LasPublish(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui(optional_value=False)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         mode = self.parameterAsInt(parameters, self.MODE, context)
@@ -203,13 +196,7 @@ class LasPublishPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui(optional_value=False)
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         mode = self.parameterAsInt(parameters, LasPublishPro.MODE, context)

--- a/LAStools/lastools/core/quality_control_information/__init__.py
+++ b/LAStools/lastools/core/quality_control_information/__init__.py
@@ -1,10 +1,10 @@
-from .lasinfo import LasInfo, LasInfoPro
-from .lasoverlap import LasOverlap, LasOverlapPro
 from .lascontrol import LasControl
+from .lasinfo import LasInfo, LasInfoPro
+from .lasoptimize import LasOptimize
+from .lasoverlap import LasOverlap, LasOverlapPro
 from .lasprobe import LasProbe
 from .lasreturn import LasReturn, LasReturnPro
 from .lasvalidate import LasValidate, LasValidatePro
-from .lasoptimize import LasOptimize
 
 __all__ = [
     LasInfo,

--- a/LAStools/lastools/core/quality_control_information/lascontrol.py
+++ b/LAStools/lastools/core/quality_control_information/lascontrol.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterString
 from qgis.PyQt.QtGui import QIcon
@@ -65,13 +64,7 @@ class LasControl(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_generic_input_commands(parameters, context, commands, "-cp")

--- a/LAStools/lastools/core/quality_control_information/lascontrol.py
+++ b/LAStools/lastools/core/quality_control_information/lascontrol.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lascontrol.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterString, QgsProcessingParameterBoolean, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterString
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasControl(LastoolsAlgorithm):

--- a/LAStools/lastools/core/quality_control_information/lasinfo.py
+++ b/LAStools/lastools/core/quality_control_information/lasinfo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasinfo.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasInfo(LastoolsAlgorithm):

--- a/LAStools/lastools/core/quality_control_information/lasinfo.py
+++ b/LAStools/lastools/core/quality_control_information/lasinfo.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -91,13 +90,7 @@ class LasInfo(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.COMPUTE_DENSITY, context):
@@ -222,13 +215,7 @@ class LasInfoPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.COMPUTE_DENSITY, context):

--- a/LAStools/lastools/core/quality_control_information/lasoptimize.py
+++ b/LAStools/lastools/core/quality_control_information/lasoptimize.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasoptimize.py
@@ -23,13 +21,12 @@ __copyright__ = "(C) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-
 # QgsProcessingParameterNumber, QgsProcessingParameterString, QgsProcessingParameterEnum,
 from qgis.core import QgsProcessingParameterBoolean
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasOptimize(LastoolsAlgorithm):

--- a/LAStools/lastools/core/quality_control_information/lasoptimize.py
+++ b/LAStools/lastools/core/quality_control_information/lasoptimize.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(C) 2025, rapidlasso GmbH"
 
-import os
 
 # QgsProcessingParameterNumber, QgsProcessingParameterString, QgsProcessingParameterEnum,
 from qgis.core import QgsProcessingParameterBoolean
@@ -56,13 +55,7 @@ class LasOptimize(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.ARGAPPEND, context):
             commands.append("-append")

--- a/LAStools/lastools/core/quality_control_information/lasoverlap.py
+++ b/LAStools/lastools/core/quality_control_information/lasoverlap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasoverlap.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasOverlap(LastoolsAlgorithm):

--- a/LAStools/lastools/core/quality_control_information/lasoverlap.py
+++ b/LAStools/lastools/core/quality_control_information/lasoverlap.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -68,13 +67,7 @@ class LasOverlap(LastoolsAlgorithm):
         self.add_parameters_raster_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_filter1_return_class_flags_commands(parameters, context, commands)
@@ -172,13 +165,7 @@ class LasOverlapPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_files_are_flightlines_commands(parameters, context, commands)

--- a/LAStools/lastools/core/quality_control_information/lasprobe.py
+++ b/LAStools/lastools/core/quality_control_information/lasprobe.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     self.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2024, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasProbe(LastoolsAlgorithm):

--- a/LAStools/lastools/core/quality_control_information/lasprobe.py
+++ b/LAStools/lastools/core/quality_control_information/lasprobe.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "March 2024"
 __copyright__ = "(C) 2024, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -60,13 +59,7 @@ class LasProbe(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         # xy pos

--- a/LAStools/lastools/core/quality_control_information/lasreturn.py
+++ b/LAStools/lastools/core/quality_control_information/lasreturn.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "March 2024"
 __copyright__ = "(C) 2024, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterBoolean
 from qgis.PyQt.QtGui import QIcon
@@ -57,13 +56,7 @@ class LasReturn(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.CHECK_RETURN_NUMBERING, context):
             commands.append("-check_return_numbering")
@@ -138,13 +131,7 @@ class LasReturnPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.CHECK_RETURN_NUMBERING, context):

--- a/LAStools/lastools/core/quality_control_information/lasreturn.py
+++ b/LAStools/lastools/core/quality_control_information/lasreturn.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasreturn.py
@@ -23,11 +21,11 @@ __copyright__ = "(C) 2024, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterBoolean, QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterBoolean
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasReturn(LastoolsAlgorithm):
@@ -59,7 +57,13 @@ class LasReturn(LastoolsAlgorithm):
         self.add_parameters_verbose_gui_64()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [os.path.join(LastoolsUtils.lastools_path(), "bin", self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext())]
+        commands = [
+            os.path.join(
+                LastoolsUtils.lastools_path(),
+                "bin",
+                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
+            )
+        ]
         self.add_parameters_point_input_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.CHECK_RETURN_NUMBERING, context):
             commands.append("-check_return_numbering")
@@ -134,7 +138,13 @@ class LasReturnPro(LastoolsAlgorithm):
         self.add_parameters_output_directory_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [os.path.join(LastoolsUtils.lastools_path(), "bin", self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext())]
+        commands = [
+            os.path.join(
+                LastoolsUtils.lastools_path(),
+                "bin",
+                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
+            )
+        ]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, self.CHECK_RETURN_NUMBERING, context):

--- a/LAStools/lastools/core/quality_control_information/lasvalidate.py
+++ b/LAStools/lastools/core/quality_control_information/lasvalidate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasvalidate.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
 from qgis.core import QgsProcessingParameterBoolean
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasValidate(LastoolsAlgorithm):

--- a/LAStools/lastools/core/quality_control_information/lasvalidate.py
+++ b/LAStools/lastools/core/quality_control_information/lasvalidate.py
@@ -103,13 +103,7 @@ class LasValidatePro(LastoolsAlgorithm):
         self.add_parameters_additional_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         if self.parameterAsBool(parameters, LasValidatePro.ONE_REPORT_PER_FILE, context):
             commands.append("-oxml")

--- a/LAStools/lastools/core/utils/__init__.py
+++ b/LAStools/lastools/core/utils/__init__.py
@@ -1,7 +1,16 @@
 """
 defining all the classes and objects
 """
-from .utils import LastoolsUtils
-from .help import paths, lastool_info, lasgroup_info, licence, help_string_help, readme_url
 
-__all__ = [LastoolsUtils, paths, lastool_info, lasgroup_info, licence, help_string_help, readme_url]
+from .help import help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
+from .utils import LastoolsUtils
+
+__all__ = [
+    LastoolsUtils,
+    paths,
+    lastool_info,
+    lasgroup_info,
+    licence,
+    help_string_help,
+    readme_url,
+]

--- a/LAStools/lastools/core/utils/help.py
+++ b/LAStools/lastools/core/utils/help.py
@@ -1,6 +1,7 @@
 """
 descriptions of all the lastools
 """
+
 import os
 from pathlib import Path
 
@@ -69,16 +70,16 @@ lasgroup_info = {
     9: {"group": "9. Pipelines & Samples", "group_id": "pipelines"},
 }
 
-fop = f'<font style="color:#CD5C5C;">'
-foe = f'<font style="color:#9400D3;">'
-fcc = f"</font>"
+fop = '<font style="color:#CD5C5C;">'
+foe = '<font style="color:#9400D3;">'
+fcc = "</font>"
 
 
 def txt_args(lastool):
     return f"{fop}additional command line arguments:{fcc} optional arguments, see {readme_link(lastool)} or examples."
 
 
-txt_folder = f"Setup for multiple files in a directory instead of single files."
+txt_folder = "Setup for multiple files in a directory instead of single files."
 txt_verbose = f"{fop}verbose:{fcc} verbose output (print extra information)."
 txt_64bit = f"{fop}64bit:{fcc} run the 64bit version of the tool (recommended)."
 txt_inlazfile = f"{fop}input LAS/LAZ file:{fcc} input file to be processed."
@@ -109,7 +110,7 @@ txt_boundary = f"""
 {fop}produce labels:{fcc} label outputs with file name, bounding box, number of points, etc ... (-labels)
 """
 txt_resolution = f"""
-{fop}resolution of x and y coordinate:{fcc} set input scale of x and y values    
+{fop}resolution of x and y coordinate:{fcc} set input scale of x and y values
 {fop}resolution of z coordinate:{fcc} set z scale
 """
 txt_filter = f"""
@@ -130,47 +131,47 @@ txt_transform = f"""
 {fop}transform:{fcc} predefined transform operations
 {fop}value for transform:{fcc} optional parameters for selected transformation
 """
-head_console_examples = f"""
+head_console_examples = """
 <h3>Console Examples</h3>
 This are LAStool command line examples. Arguments can be set by the parameters of the plugin or by the additional command line arguments field.
 """
 txt_parse = f"""
-{fop}parse string tokens{fcc} (see REAME file for full list)<br>x : [x] coordinate<br>y : [y] coordinate<br>z : [z] coordinate<br>t : gps [t]ime<br>R : RGB [R]ed channel<br>G : RGB [G]reen channel<br>B : RGB [B]lue channel<br>I : N[I]R channel (LAS 1.4|8)<br>s : [s]kip a string or a number that we don't care about<br>i : [i]ntensity<br>a : scan [a]ngle<br>n : [n]umber of returns of that given pulse<br>r : number of [r]eturn<br>h : with[h]eld flag<br>k : [k]eypoint flag<br>g : synthetic fla[g]<br>o : [o]verlap flag (LAS 1.4|6-8)<br>l : scanner channe[l] (LAS 1.4|6-8)<br>c : [c]lassification<br>u : [u]ser data<br>p : [p]oint source ID<br>e : [e]dge of flight line flag<br>d : [d]irection of scan flag<br>0-9 : additional attributes / extra bytes (0..9)<br>(13) : additional attributes / extra bytes (10+)  
+{fop}parse string tokens{fcc} (see REAME file for full list)<br>x : [x] coordinate<br>y : [y] coordinate<br>z : [z] coordinate<br>t : gps [t]ime<br>R : RGB [R]ed channel<br>G : RGB [G]reen channel<br>B : RGB [B]lue channel<br>I : N[I]R channel (LAS 1.4|8)<br>s : [s]kip a string or a number that we don't care about<br>i : [i]ntensity<br>a : scan [a]ngle<br>n : [n]umber of returns of that given pulse<br>r : number of [r]eturn<br>h : with[h]eld flag<br>k : [k]eypoint flag<br>g : synthetic fla[g]<br>o : [o]verlap flag (LAS 1.4|6-8)<br>l : scanner channe[l] (LAS 1.4|6-8)<br>c : [c]lassification<br>u : [u]ser data<br>p : [p]oint source ID<br>e : [e]dge of flight line flag<br>d : [d]irection of scan flag<br>0-9 : additional attributes / extra bytes (0..9)<br>(13) : additional attributes / extra bytes (10+)
 """
-txt_laszip_intro = f"Compresses and uncompresses LiDAR data stored in binary LAS format (1.0 - 1.4) in a completely lossless manner to the compressed LAZ format."
-txt_laszip_outro = f"Default output is the same file than the input file but with oposite file ending: A file.laz will be converted to file.las just as vice versa."
-txt_las2las_intro = f"""
+txt_laszip_intro = "Compresses and uncompresses LiDAR data stored in binary LAS format (1.0 - 1.4) in a completely lossless manner to the compressed LAZ format."
+txt_laszip_outro = "Default output is the same file than the input file but with oposite file ending: A file.laz will be converted to file.las just as vice versa."
+txt_las2las_intro = """
 las2las is the "swiss-army knife" of LiDAR file processing. It can convert, filter, transform, subset, repair, scale, translate, zero, clamp, compress, initialize, reproject, georeference,... LAS or LAZ files in numerous ways. The tool is 100% open source LGPL.<br>Sometimes it is not neccessary to use las2las prior other LAStools, because most arguments can be used by the other tools as well.
 """
-txt_las2las_filter = f"las2las with parameters to filter pointclouds"
-txt_las2las_trans = f"las2las with parameters to translate pointclouds"
-txt_las2las_project = f"las2las with parameters to change projection and georeferencing"
+txt_las2las_filter = "las2las with parameters to filter pointclouds"
+txt_las2las_trans = "las2las with parameters to translate pointclouds"
+txt_las2las_project = "las2las with parameters to change projection and georeferencing"
 txt_las2txt_short = (
-    f"converts binary LAS or LAZ files to human readable ASCII text format using a user specific parse argument"
+    "converts binary LAS or LAZ files to human readable ASCII text format using a user specific parse argument"
 )
 txt_las2txt_intro = f"""
 {txt_las2txt_short}.<br>This can be used to modify lidar data external and convert them back to LAS/LAZ using txt2las.
 """
-txt_txt2las_short = f"Converts ASCII files to binary LAS or compressed LAZ file"
+txt_txt2las_short = "Converts ASCII files to binary LAS or compressed LAZ file"
 txt_txt2las_intro = f"""{txt_txt2las_short}.<br>Use the parse string to define the ascii content or use the column headers in the file."""
-txt_e572las_short = f"Converts 3D point files in E57 format to binary LAS/LAZ format"
+txt_e572las_short = "Converts 3D point files in E57 format to binary LAS/LAZ format"
 txt_e572las_intro = f"""{txt_e572las_short}.<br>By default all scans contained in the E57 file are merged into one output with all invalid points being omitted. The points of different scans are given different point source IDs so that the information which points belong to one scan is preserved.  It's possible to request '-split_scans' and '-include_invalid' to put points from different scans into separate files and/or to include invalid points as well.<br>Sample data can be found at <a href="http://www.libe57.org/data.html">libe57.org</a>.
 By default the tool will apply transformations and/or rotations that it find stored in the pose of each scan. You can ask the tool not to apply those with '-no_pose'. To selevtively suppress only transformation or rotation use '-no_transformation' or '-no_rotation'<br>This tool does not support multiple file input. Batch conversion can be done using a batch file like
 {fop}:: convert all *.e57 files to *.laz<br>for %%f in (*.e57) do if not exist %%~nf.laz e572las -i %%f -olaz{fcc}
 """
-txt_las2shp_short = f"Converts LIDAR from LAS/LAZ/ASCII to ESRI’s Shapefile format by grouping consecutive points into MultiPointZ records"
-txt_shp2las_short = f"Converts from points from ESRI’s Shapefile to LAS/LAZ/ASCII format, given the input, contains Points or MultiPoints"
-txt_lasplanes_short = f"Finds sufficiently planar patches of LAS/LAZ points"
-txt_shp2las_short = f"Converts from points from ESRI’s Shapefile to LAS/LAZ/ASCII format, given the input, contains Points or MultiPoints"
-txt_las3dpoly_rad_short = f"Modifies points within a certain radial distance of 3D polylines"
-txt_las3dpoly_xy_short = f"Modifies points within a certain horizontal and vertical distance of 3D polylines"
-txt_las3dpoly_intro = f"""
+txt_las2shp_short = "Converts LIDAR from LAS/LAZ/ASCII to ESRI’s Shapefile format by grouping consecutive points into MultiPointZ records"
+txt_shp2las_short = "Converts from points from ESRI’s Shapefile to LAS/LAZ/ASCII format, given the input, contains Points or MultiPoints"
+txt_lasplanes_short = "Finds sufficiently planar patches of LAS/LAZ points"
+txt_shp2las_short = "Converts from points from ESRI’s Shapefile to LAS/LAZ/ASCII format, given the input, contains Points or MultiPoints"
+txt_las3dpoly_rad_short = "Modifies points within a certain radial distance of 3D polylines"
+txt_las3dpoly_xy_short = "Modifies points within a certain horizontal and vertical distance of 3D polylines"
+txt_las3dpoly_intro = """
 This tool modifies points within a certain distance of polylines. As an input take, for example, a LAS/LAZ/TXT file and a SHP/TXT file with one or many polylines (e.g. powerlines) by specify a radial distance to the 3D polygon. Affected points can be classified, clipped, or flagged.<br>The input SHP/TXT file must contain clean polygons or polylines that are free of self-intersections, duplicate points, and/or overlaps and they must all form closed loops (e.g. the last and first point should be identical).
 An input 'line.csv' may look like-10,0,0<br>10,0,0<br>0,0,0<br>0,-10,0<br>0,10,0"""
-txt_lasdistance_short = f"Classifies, flags, or remove points within a specified distance of polygonal segments"
-txt_lasdistance_intro = f"""
+txt_lasdistance_short = "Classifies, flags, or remove points within a specified distance of polygonal segments"
+txt_lasdistance_intro = """
 The distance is calculated on a grid with a spacing of 0.5 meters by default. With '-step_xy 1.0' the granularity of this grid can be adjusted up or down."""
-txt_lasintensity_short = f"corrects the intensity attenuation due to atmospheric absorption"
+txt_lasintensity_short = "corrects the intensity attenuation due to atmospheric absorption"
 txt_lasintensity_intro = f"""
 {txt_lasintensity_short}.
 This tool corrects the intensity attenuation due to atmospheric absorption.<br>Because the light has to travel longer distances for points with large scan angles, these points may be detected with reduced intensities.
@@ -178,73 +179,71 @@ In order to get a reliant attenuation estimate several parameters are essential:
 """
 txt_lasindex_short = "Creates an index file (*.lax) about a LAS/LAZ file"
 txt_index_intro = f"""
-{txt_lasindex_short}. The file contains spatial indexing information. When this LAX file is present it will be used to speed up access to the relevant areas of the LAS/LAZ file.                   
+{txt_lasindex_short}. The file contains spatial indexing information. When this LAX file is present it will be used to speed up access to the relevant areas of the LAS/LAZ file.
 """
 txt_lasprobe_short = (
-    f"Probes the elevation of the LIDAR for a given x and y location and reports it to a text file or to stdout"
+    "Probes the elevation of the LIDAR for a given x and y location and reports it to a text file or to stdout"
 )
-txt_merge_short = f"Merge multiple LiDAR files into one"
-txt_merge_intro = f"""
+txt_merge_short = "Merge multiple LiDAR files into one"
+txt_merge_intro = """
 This is a handy tool to merge multiple LiDAR files into one. However, we usually discourage this practice as this can also be achieved on-the-fly with the ‘-merged’ option in any of the other LAStools without creating a second copy on disk. In addition this tools allows splitting larger files into smaller subsets each containing a user-specified number of points.
 """
-txt_lasoverage_short = f"Finds “overage” points that get covered by more than a single flightline"
-txt_lasoverage_intro = f"""
+txt_lasoverage_short = "Finds “overage” points that get covered by more than a single flightline"
+txt_lasoverage_intro = """
 Reads LiDAR points of an airborne collect and finds the “overage” points that get covered by more than a single flightline. It either marks these overage points or removes them from the output files. The tool requires that the files either have the flightline information stored for each point in the point source ID field (e.g. for tiles containing overlapping flightlines) or that there are multiple files where each corresponds to a flight line (‘-files_are_flightlines’). It is also required that the scan angle field of each point is properly populated.
 """
-txt_lasboundary_short = f"Computes a boundary polygon that encloses LIDAR points"
+txt_lasboundary_short = "Computes a boundary polygon that encloses LIDAR points"
 txt_lasboundary_intro = f"""{txt_lasboundary_short}.
 Reads LIDAR from LAS/LAZ/ASCII files and computes a boundary polygon that encloses the points. By default this is a joint concave hull where “islands of points” are connected by edges that are traversed in each direction once. Optionally a disjoint concave hull is computed with the ‘-disjoint’ flag. This can lead to multiple hulls in case of islands. Note that tiny islands of the size of one or two LIDAR points that are too small to form a triangle will be “lost”."""
-txt_lasclip_short = f"Clip LIDAR data by polygons"
-txt_lasreturn_short = f"Reports geometric returns statistics and repairs ‘number of returns’ field"
-txt_lasreturn_intro = f"""Reports geometric return statistics for multi-return pulses and repairs the 'number of returns' field based on GPS times. Note that input files need (currently) to be sorted based on their GPS time stamp. It can also compute the 3D distance (or gaps) between subsequent returns of the same pulse. It can also check for missing or duplicate returns per laser shot and create output files where the problematic groups of returns are marked."""
-txt_lassort_short = f"Sorts LIDAR data by elevation, gps_time or point_source"
-txt_lassort_intro = f"""sorts the points of a LAS file into z-order arranged cells of a square quad tree and saves them into LAS or LAZ format. This is useful to bucket together returns from different swaths or to merge first and last returns that were stored in separate files.For standard LAS/LAZ files one simply chooses a -bucket_size to specify the resolution of finest quad tree cell. A bucket size of, for example, 5 creates 5x5 unit buckets. The z-order traversal of the quad tree creates implicit "finalization tags" that can later be used for streaming processing.<br>For LAS/LAZ files that are part of a tiling that was created with lastile it is beneficial to specify the resolution via the number of -levels of subtiling this tile. This has the advantage that both the tiling and the subtiling can be used during streaming processing.<br>Another option is -average to coarsen the resolution of the quadtree until the average number of points per cell is as specified.<br>The square quad tree used by lassort can (eventually) be exploited by "streaming TIN" generation code to seamlessly Delaunay triangulate large LAS/LAZ files (or large amounts of LAS/LAZ tiles) in a highly memory-efficient fashion. For that purpose, lassort either adds (or updates) a small VLR to the header the generated LAS/LAZ file.<br>Large amounts of LAS data should first be sorted into tiles with lastile - which operates out-of-core - because lassort does its bucket sort in memory.<br>Alternatively lassort can sort a LAS/LAZ file in GPS time order or in a point source ID order (or first sort by point source IDs and then by time)."""
-txt_lastile_short = f"Tiles LIDAR points into tiles"
-txt_lastile_intro = f"""Tiles a potentially very large amount of LAS/LAZ/ASCII points from one  or many files into square non-overlapping tiles of a specified size and save them into LAS or LAZ format. Optionally the tool can also create a small ‘-buffer 10’ around every tile where the parameter 10 specifies the number of units each tile is (temporarily) grown in each direction. It is possible to remove the buffer from a tile by running with ‘-remove_buffer’ option. You may also flag the points that fall into the buffer with the new ‘-flag_as_withheld’ or ‘-flag_as_synthetic’ options. If you spatially index your input files using lasindex you may also run lastile on multiple processors with the ‘-cores 4’ option."""
-txt_lassplit_short = f"Splits LAS or LAZ files into multiple files"
+txt_lasclip_short = "Clip LIDAR data by polygons"
+txt_lasreturn_short = "Reports geometric returns statistics and repairs ‘number of returns’ field"
+txt_lasreturn_intro = """Reports geometric return statistics for multi-return pulses and repairs the 'number of returns' field based on GPS times. Note that input files need (currently) to be sorted based on their GPS time stamp. It can also compute the 3D distance (or gaps) between subsequent returns of the same pulse. It can also check for missing or duplicate returns per laser shot and create output files where the problematic groups of returns are marked."""
+txt_lassort_short = "Sorts LIDAR data by elevation, gps_time or point_source"
+txt_lassort_intro = """sorts the points of a LAS file into z-order arranged cells of a square quad tree and saves them into LAS or LAZ format. This is useful to bucket together returns from different swaths or to merge first and last returns that were stored in separate files.For standard LAS/LAZ files one simply chooses a -bucket_size to specify the resolution of finest quad tree cell. A bucket size of, for example, 5 creates 5x5 unit buckets. The z-order traversal of the quad tree creates implicit "finalization tags" that can later be used for streaming processing.<br>For LAS/LAZ files that are part of a tiling that was created with lastile it is beneficial to specify the resolution via the number of -levels of subtiling this tile. This has the advantage that both the tiling and the subtiling can be used during streaming processing.<br>Another option is -average to coarsen the resolution of the quadtree until the average number of points per cell is as specified.<br>The square quad tree used by lassort can (eventually) be exploited by "streaming TIN" generation code to seamlessly Delaunay triangulate large LAS/LAZ files (or large amounts of LAS/LAZ tiles) in a highly memory-efficient fashion. For that purpose, lassort either adds (or updates) a small VLR to the header the generated LAS/LAZ file.<br>Large amounts of LAS data should first be sorted into tiles with lastile - which operates out-of-core - because lassort does its bucket sort in memory.<br>Alternatively lassort can sort a LAS/LAZ file in GPS time order or in a point source ID order (or first sort by point source IDs and then by time)."""
+txt_lastile_short = "Tiles LIDAR points into tiles"
+txt_lastile_intro = """Tiles a potentially very large amount of LAS/LAZ/ASCII points from one  or many files into square non-overlapping tiles of a specified size and save them into LAS or LAZ format. Optionally the tool can also create a small ‘-buffer 10’ around every tile where the parameter 10 specifies the number of units each tile is (temporarily) grown in each direction. It is possible to remove the buffer from a tile by running with ‘-remove_buffer’ option. You may also flag the points that fall into the buffer with the new ‘-flag_as_withheld’ or ‘-flag_as_synthetic’ options. If you spatially index your input files using lasindex you may also run lastile on multiple processors with the ‘-cores 4’ option."""
+txt_lassplit_short = "Splits LAS or LAZ files into multiple files"
 txt_lassplit_intro = f"""{txt_lassplit_short} based on some criteria. By default it splits the points into separate files based on the ‘point source ID’ field that usually contains the flightline ID."""
-txt_lasnoise_short = f"Flags or removes noise points in LAS or LAZ files"
+txt_lasnoise_short = "Flags or removes noise points in LAS or LAZ files"
 txt_lasnoise_intro = f"""{txt_lasnoise_short}. The tool looks for isolated points according to certain criteria that can be modified via ‘-step 3’ and ‘-isolated 3’ as needed. The default for step is 4 and for isolated is 5. It is possible to specify the xy and the z size of the 27 cells separately with ‘-step_xy 2’ and ‘-step_z 0.3’ which would create cells of size 2 by 2 by 0.3 units.
 The tool tries to find points that have only few other points in their surrounding 3 by 3 by 3 grid of cells with the cell the respective point falls into being in the center. The size of each of the 27 cells is set with the ‘-step 5’ parameter. The maximal number of few other points in the 3 by 3 by 3 grid still designating a point as isolated is set with ‘-isolated 6’.
 By default the noise points are given the classification code 7 (low or high noise). Using the ‘-remove_noise’ flag will instead remove them from the output file. Alternatively with the ‘-classify_as 31’ switch a different classification code can be selected. Another option is the ‘-flag_as_withheld’ switch which sets the withheld flag on the points identified as noise."""
 txt_lasdiff_short = (
-    f"Compares the LIDAR data of two LAS/LAZ/ASCII files and reports whether they are identical or different"
+    "Compares the LIDAR data of two LAS/LAZ/ASCII files and reports whether they are identical or different"
 )
-txt_lasground_short = f"Tool for bare-earth extraction"
+txt_lasground_short = "Tool for bare-earth extraction"
 txt_lasground_intro = f"""{txt_lasground_short}: It classifies the LiDAR points into ground points (class = 2) and non-ground points (class = 1). The tools works very well in natural environments such as mountains, forests, fields, hills, and even steep terrain but also gives excellent results in towns or cities."""
-txt_lasgroundnew_short = f"This is a redesigned tool for bare-earth extraction"
+txt_lasgroundnew_short = "This is a redesigned tool for bare-earth extraction"
 txt_lasgroundnew_intro = f"""{txt_lasgroundnew_short}. It classifies LIDAR points into ground points (class = 2) and non-ground points (class = 1). This is a totally redesigned version of lasground that handles complicated terrain much better where there are steep mountains nearby urban areas with many buildings."""
-txt_lasclassify_short = f"Classify buildings and high vegetation"
+txt_lasclassify_short = "Classify buildings and high vegetation"
 txt_lasclassify_intro = f"""{txt_lasclassify_short} (i.e. trees) in LAS/LAZ files. This tool requires that the bare-earth points have already been identified (e.g. with lasground) and that the elevation of each point above the ground was already computed with lasheight."""
-txt_lasthin_short = f"A simple LIDAR thinning algorithm"
+txt_lasthin_short = "A simple LIDAR thinning algorithm"
 txt_lasthin_intro = f"""{txt_lasthin_short} for LAS/LAZ/ASCII. It places a uniform grid over the points and within each grid cell keeps only the point with the lowest (or ‘-highest’) Z coordinate a -random’ point per cell or the most ‘-central’ one. When keeping ‘-random’ points you can in addition specify a ‘-seed 232’ for the random generator. Instead of removing the thinned out points from the output file you can also flag them with ‘-flag_as_withheld’ or ‘-flag_as_keypoint’. Then you can use the standard ‘-drop_withheld’ or ‘-keep_withheld’ filters to get either the thinned points or their complement.    """
-txt_las2dem_short = f"Triangulates LIDAR points from LAS/LAZ to TIN and DEM"
+txt_las2dem_short = "Triangulates LIDAR points from LAS/LAZ to TIN and DEM"
 txt_las2dem_intro = f"""{txt_las2dem_short}. Triangulates LIDAR points from the LAS/LAZ format (or some ASCII format) into a temporary TIN and then rasters the TIN to create a DEM. The tool can either raster the ‘-elevation’, the ‘-slope’, the ‘-intensity’, the ‘-rgb’ values, or a ‘-hillshade’ or ‘-gray’ or ‘-false’ coloring. The output is either in BIL, ASC, IMG, FLT, XYZ, DTM, TIF, PNG or JPG format."""
-txt_las2iso_short = f"Extracts elevation contours to SHP/KML/WKT/TXT format"
+txt_las2iso_short = "Extracts elevation contours to SHP/KML/WKT/TXT format"
 txt_las2iso_intro = f"""{txt_las2iso_short}. The tool reads LIDAR points from LAS/LAZ/ASCII (or rasters from ASC/BIL/DTM format) and extracts a set of particular elevation contours in SHP/KML/WKT/TXT format. The user may specify to extract contours every 5 meters or only for individual elevation values. The contours can be smoothed or simplified on demand and hydro breaklines can be specified as well. las2iso can handle files up to about 20 mio. points."""
-txt_lasgrid_short = f"Raster huge LiDAR collections into grids by elevation, intensity or many other parameters"
+txt_lasgrid_short = "Raster huge LiDAR collections into grids by elevation, intensity or many other parameters"
 txt_lasgrid_intro = f"""{txt_lasgrid_short}. The most important parameter ‘-step n’ specifies the n x n area that of LiDAR points that are gridded on one raster cell (or pixel). The output is either in BIL, ASC, IMG, TIF, PNG, JPG, XYZ, FLT, or DTM format. The tool can raster the ‘-elevation’ or the ‘-intensity’ of each point and stores the ‘-lowest’ or the ‘-highest’, the ‘-average’, or the standard deviation ‘-stddev’. Other gridding options are ‘-scan_angle_abs’, ‘-counter’, ‘-counter_16bit’, ‘-counter_32bit’, ‘-user_data’, ‘-point_source’, and others."""
-txt_lasheight_short = f"Computes the height of each point above the ground"
+txt_lasheight_short = "Computes the height of each point above the ground"
 txt_lasheight_intro = f"""{txt_lasheight_short}. This assumes that grounds points have already been ground-classified (with standard classification 2 or selected with ‘-class 31’ or ‘-classification 8’) so they can be identified to construct a ground TIN. The ground points can also be in an separate file ‘-ground_points ground.las’ or ‘-ground_points dtm.csv -parse ssxyz’. By default the resulting heights are quantized, scaled with a factor of 10, clamped into an unsigned char between 0 and 255, and stored in the “user data” field of each point. Optional other target fields can be defined."""
-txt_lasheight_class = f"Extra parameters to classify by height above ground."
-txt_lascanopy_short = f"Computes common forestry metrics from height-normalized LiDAR point clouds"
+txt_lasheight_class = "Extra parameters to classify by height above ground."
+txt_lascanopy_short = "Computes common forestry metrics from height-normalized LiDAR point clouds"
 txt_lascanopy_intro = f"""{txt_lascanopy_short}. It can compute canopy density or canopy cover (or gap fractions), height or intensity percentiles, averages, minima, maxima, kurtosis, skewness, standard deviation, and many more."""
-txt_lascolor_short = f"Colors LiDAR points based on imagery that is usually an ortho-photo"
+txt_lascolor_short = "Colors LiDAR points based on imagery that is usually an ortho-photo"
 txt_lascolor_intro = f"""{txt_lascolor_short}. The tool computes into which pixel a LAS point is falling and then sets the RGB values accordingly. Currently only the TIF format is supported. The world coordinates need to be either in GeoTIFF tags or in an accompanying *.tfw file."""
-txt_blast2dem_short = (
-    f"Rasters billions of LiDAR points via a streaming TIN to elevation, intensity, slope, or RGB grid"
-)
-txt_blast2dem_intro = f"""{txt_blast2dem_short}. blast2dem is almost identical to las2dem except that it can process much much larger inputs. While las2dem operates in-core and is therefore limited to a maximum of around 20 million points, blast2dem utilizes unique “streaming TIN” technology and can seamlessly process up to 2 billion points. This tool is part of the BLAST extension of LAStools. 
+txt_blast2dem_short = "Rasters billions of LiDAR points via a streaming TIN to elevation, intensity, slope, or RGB grid"
+txt_blast2dem_intro = f"""{txt_blast2dem_short}. blast2dem is almost identical to las2dem except that it can process much much larger inputs. While las2dem operates in-core and is therefore limited to a maximum of around 20 million points, blast2dem utilizes unique “streaming TIN” technology and can seamlessly process up to 2 billion points. This tool is part of the BLAST extension of LAStools.
 """
-txt_blast2iso_short = f"Contours billions of LiDAR points via a streaming TIN to isolines in KML or SHP format"
+txt_blast2iso_short = "Contours billions of LiDAR points via a streaming TIN to isolines in KML or SHP format"
 txt_blast2iso_intro = f"""{txt_blast2iso_short}. blast2iso is almost identical to las2iso except that it can extract elevation contours from much much larger inputs. While las2iso operates in-core and is therefore limited to a maximum of around 20 million points, blast2iso utilizes unique “streaming TIN” technology and can seamlessly process up to 2 billion points. This tool is part of the BLAST extension of LAStools."""
-txt_lasinfo_short = f"Report all content of a LAS/LAZ file header"
+txt_lasinfo_short = "Report all content of a LAS/LAZ file header"
 txt_lasinfo_intro = f"""{txt_lasinfo_short}. This is a handy tool report the contents of the header, the VLRs, and a short summary of the min and max values of the points for LAS/LAZ files. The tool warns when there is a difference between the header information and the point content for counters and bounding box extent."""
-txt_lasoverlap_short = f"Computes the flight line overlap and alignment of LIDAR points"
+txt_lasoverlap_short = "Computes the flight line overlap and alignment of LIDAR points"
 txt_lasoverlap_intro = f"""{txt_lasoverlap_short}. Reads LIDAR points from LAS/LAZ or ASCII files and computes the flight line overlap and/or the vertical and horizontal alignment. The output rasters can either be a color coded visual illustration of the level of overlap or the differences or the actual values and can be either in BIL, ASC, IMG, FLT, XYZ, DTM, TIF, PNG or JPG format."""
-txt_lascontrol_short = f"Computes the elevation of LiDAR data at specific x/y control points"
+txt_lascontrol_short = "Computes the elevation of LiDAR data at specific x/y control points"
 txt_lascontrol_intro = f"""{txt_lascontrol_short}. Reports the difference in respect to the control point elevation. The tool reads LiDAR in LAS/LAZ/ASCII format, triangulates the relevant points around the control points into a TIN."""
-txt_lasduplicate_short = f"Removes duplicate LiDAR points with identical x,y and optionally z coordinates"
+txt_lasduplicate_short = "Removes duplicate LiDAR points with identical x,y and optionally z coordinates"
 txt_lasduplicate_intro = f"""{txt_lasduplicate_short}. In the default mode those are xy-duplicate points that have identical x and y coordinates. The first point survives, all subsequent duplicates are removed. It is also possible to keep the lowest points amongst all xy-duplicates via '-lowest_z'.
 It is also possible to remove only xyz-duplicates points that have all x, y and z coordinates identical via '-unique_xyz'.
 Another option is to identify '-nearby 0.005' points into one so that multiple returns within a specified distance become a single return. Given all pairs of points p1 and p2 (with p1 being before p2 in the file), point p2 will not be part of the output if these three conditions on their quantized coordinates are true
@@ -256,29 +255,29 @@ after quantizing them as follows based on the '-nearby d' value
   p1.qy = round(p1.y / d)     p2.qy = round(p2.y / d)
   p1.qz = round(p1.z / d)     p2.qz = round(p2.z / d)
 The special option '-single_returns' was added particularly to reconstruct the single versus multiple return information for the (unfortunate) case that the LiDAR points were delivered in two separate files with some points appearing in both. These LiDAR points may be split into all first return and all last returns or into all first returns and all ground returns. See the example below how to deal with this case correctly.<br>The removed points can also be recorded to a LAZ file with the option '-record_removed'."""
-txt_lasprecision_short = f"Finds the actual precision of LiDAR points and allows to correct the scaling if necessary"
+txt_lasprecision_short = "Finds the actual precision of LiDAR points and allows to correct the scaling if necessary"
 txt_lasprecision_intro = f"""{txt_lasprecision_short}. Reads LIDAR data in the LAS/LAZ format and computes statistics that tell us whether the precision "advertised" in the header is really in the data."""
-txt_lasvalidate_short = f"Determine if LAS files conform to the ASPRS LAS specifications"
-txt_lasvalidate_intro = f"""A simple tool to validate whether a single or a folder of LAS or LAZ files conform to the LAS specification of the ASPRS."""
-txt_lasoptimize_short = f"Optimize, compress and spatially index LiDAR files before distribution"
+txt_lasvalidate_short = "Determine if LAS files conform to the ASPRS LAS specifications"
+txt_lasvalidate_intro = """A simple tool to validate whether a single or a folder of LAS or LAZ files conform to the LAS specification of the ASPRS."""
+txt_lasoptimize_short = "Optimize, compress and spatially index LiDAR files before distribution"
 txt_lasoptimize_intro = f"""{txt_lasoptimize_short}.
 Optimizes LiDAR stored in binary LAS or LAZ format (1.0 - 1.4) for better compression and spatial coherency. Especially useful prior to distributing LiDAR via data portals to lower bandwidth and storage but also accelerate subsequent exploitation.<br>In the default setting the tool will do the following:<br>- remove fluff in coordinate resolution (i.e. when all X, Y, or Z coordinates are multiples of 10, 100, or 1000).<br>- remove any additional padding in the LAS header or before the point block<br>- set nicely rounded offsets in the LAS header<br>- zero the contents of the user data field<br>- turn (sufficiently small) EVLRs into VLRs (LAS 1.4 only)<br>- rearrange points for better compression and spatial indexing<br>Arguments allows turning off the options."""
-txt_lascopy_short = f"Copies selected point attributes from a reference file to a target file"
+txt_lascopy_short = "Copies selected point attributes from a reference file to a target file"
 txt_lascopy_intro = f"""{txt_lascopy_short}.
 Merging the data is done by a match key. The key is GPS time and return number by default but can be also other or a combination of fields.
 See the -match... arguments.<br>By default the selected attributes of the source points are copied to all target points if the two share the exact same combination of key values.
 Selecting attributes to be copied is done by adding one or more '-copy_...' arguments. If no selection is made the classifications are copied.
 By default the points from the target file that have no match in the source file remain unchanged unless the option '-zero' is used that set the selected attributes to 0 instead.
 A simpler copy can be activated with option '-unmatched' which does not check for identical GPS-time and return number but simply copies the requested attribute in the order the point are in."""
-txt_laspublish_short = f"Creates a LiDAR portal for 3D visualization (and optionally also for downloading) of LAS and LAZ files in any modern Web browser"
+txt_laspublish_short = "Creates a LiDAR portal for 3D visualization (and optionally also for downloading) of LAS and LAZ files in any modern Web browser"
 txt_laspublish_intro = (
     f'{txt_laspublish_short} using the <a href="https://github.com/potree/potree">WebGL Potree</a> from Markus Schuetz.'
 )
-txt_lasview_short = f"Simple and fast LiDAR visualization tool"
+txt_lasview_short = "Simple and fast LiDAR visualization tool"
 txt_lasview_intro = f"""
 {txt_lasview_short} that has a number of neat little tricks that may surprise you. It can also edit the classification of the points as well as delete them.<br>As an optional viewer see <a href="https://rapidlasso.de/laslook">laslook</a>, the new GUI workbench for LAStools.
 """
-txt_lasvoxel_short = f"Computes various voxelizations for LiDAR point clouds"
+txt_lasvoxel_short = "Computes various voxelizations for LiDAR point clouds"
 
 # tools
 lastool_info = {
@@ -292,7 +291,7 @@ lastool_info = {
 See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex</a> about index files (*.lax).
 {txt_verbose}
 {txt_64bit}
-{txt_laszip_outro}             
+{txt_laszip_outro}
 {head_console_examples}
     {foe}laszip lake.las{fcc}<br>compresses LAS file "lake.las" to an lossless packed LAZ file overwriting any existing file.
     {foe}laszip lake.laz{fcc}<br>decompresses LAS file "lake.las" to an uncompressed LAS file overwriting any existing file.
@@ -311,7 +310,7 @@ See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex
 {txt_cores}
 {txt_verbose}
 {txt_64bit}
-{txt_laszip_outro}             
+{txt_laszip_outro}
 {head_console_examples}
     {foe}laszip *.las{fcc}<br>compresses all LAS files in the current folder overwriting any existing file.
     {foe}laszip *.laz{fcc}<br>decompresses all LAZ files in the current folder overwriting any existing file.
@@ -355,7 +354,7 @@ See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex
 {txt_verbose}
 {txt_64bit}
 {head_console_examples}
-    {foe}las2las -i *.las -o *.las -keep_z 10 100{fcc}<br>copy all input files to an output file but keep only z values between 10 and 100. 
+    {foe}las2las -i *.las -o *.las -keep_z 10 100{fcc}<br>copy all input files to an output file but keep only z values between 10 and 100.
         """,
         "desc": f"{txt_las2las_filter}",
     },
@@ -434,7 +433,7 @@ See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex
 {txt_las2shp_short}.
 <h3>Parameters</h3>
 {txt_inlazfile}
-{fop}use PointZ instead of MultiPointZ:{fcc} Create PointZ records instead of MultiPointZ records (-single_points). 
+{fop}use PointZ instead of MultiPointZ:{fcc} Create PointZ records instead of MultiPointZ records (-single_points).
 {fop}number of points per record:{fcc} Set argument "-record" value.
 {txt_args("las2shp")}
 {txt_verbose}
@@ -498,8 +497,8 @@ See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex
 <h3>Parameters</h3>
 {txt_inshpfile}
 {txt_resolution}
-{fop}resolution of x and y coordinate:{fcc} set input scale to quantize points    
-{fop}resolution of z coordinate:{fcc} set z scale to quantize points    
+{fop}resolution of x and y coordinate:{fcc} set input scale to quantize points
+{fop}resolution of z coordinate:{fcc} set z scale to quantize points
 {txt_args("shp2las")}
 {txt_verbose}
 {head_console_examples}
@@ -521,7 +520,7 @@ See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex
 {txt_64bit}
 {head_console_examples}
     {foe}txt2las -i file.txt -o out.laz{fcc}<br>read the textfile and convert it to a LAZ file. Expect the first row as column headers to identify the target field.
-    {foe}txt2las -i file.txt -o out.laz -parse xyzai -scale_scan_angle 57.3 -scale_intensity 65535{fcc}<br>read the textfile with x y z scan angle (multiplied by 57.3; radian to angle) and the 5th entry as the intensity and multiplies it by 65535 (converts range [0.0 .. 1.0] to range [0 .. 65535]. Output as compressed LAZ file.        
+    {foe}txt2las -i file.txt -o out.laz -parse xyzai -scale_scan_angle 57.3 -scale_intensity 65535{fcc}<br>read the textfile with x y z scan angle (multiplied by 57.3; radian to angle) and the 5th entry as the intensity and multiplies it by 65535 (converts range [0.0 .. 1.0] to range [0 .. 65535]. Output as compressed LAZ file.
         """,
         "desc": f"{txt_txt2las_short}",
     },
@@ -540,7 +539,7 @@ See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex
 {txt_verbose}
 {txt_64bit}
 {head_console_examples}
-    {foe}txt2las -skip 3 -i *.txt.gz -odir out -olaz -parse txyzsa -sp83 OH_N{fcc}<br>converts all gzipped ASCII files and uses the 1st entry of each line as the gps time, the 3rd, 4th, and 5th entry as the x, y, and z coordinate of each point, and the 6th entry as the scan angle. It skips the first three lines of the ASCII data file and adds projection info for state plane ohio north with nad83.             
+    {foe}txt2las -skip 3 -i *.txt.gz -odir out -olaz -parse txyzsa -sp83 OH_N{fcc}<br>converts all gzipped ASCII files and uses the 1st entry of each line as the gps time, the 3rd, 4th, and 5th entry as the x, y, and z coordinate of each point, and the 6th entry as the scan angle. It skips the first three lines of the ASCII data file and adds projection info for state plane ohio north with nad83.
         """,
         "desc": f"{txt_txt2las_short}",
     },
@@ -555,7 +554,7 @@ See <a href="https://downloads.rapidlasso.de/readme/lasindex_README.md">lasindex
 {txt_64bit}
 {head_console_examples}
     {foe}e572las -i file.txt -o out.laz{fcc}<br>read the textfile and convert it to a LAZ file. Expect the first row as column headers to identify the target field.
-    {foe}e572las -i file.txt -o out.laz -parse xyzai -scale_scan_angle 57.3 -scale_intensity 65535{fcc}<br>read the textfile with x y z scan angle (multiplied by 57.3; radian to angle) and the 5th entry as the intensity and multiplies it by 65535 (converts range [0.0 .. 1.0] to range [0 .. 65535]. Output as compressed LAZ file.        
+    {foe}e572las -i file.txt -o out.laz -parse xyzai -scale_scan_angle 57.3 -scale_intensity 65535{fcc}<br>read the textfile with x y z scan angle (multiplied by 57.3; radian to angle) and the 5th entry as the intensity and multiplies it by 65535 (converts range [0.0 .. 1.0] to range [0 .. 65535]. Output as compressed LAZ file.
         """,
         "desc": f"{txt_e572las_short}",
     },
@@ -601,7 +600,7 @@ More merge and copy arguments see README file.
 <h3>Parameters</h3>
 {txt_inlazfile}
 {txt_inpolyfile}
-{fop}vertical distance:{fcc} Vertical distance to polygon to match points 
+{fop}vertical distance:{fcc} Vertical distance to polygon to match points
 {fop}horizontal distance:{fcc} Horizontal distance to polygon to match points
 {txt_args("las3dpoly")}
 {txt_verbose}
@@ -622,7 +621,7 @@ More merge and copy arguments see README file.
 {txt_verbose}
 {txt_64bit}
 {head_console_examples}
-    {foe}las3dpoly -i in.laz -poly line.shp -o out.laz -distance 10 -classify_as 13 -v{fcc}<br>classify all points within the result file as class 13 if they are within radial distance=10 to the line specified by line.shp and list a verbose report of what has been done. 
+    {foe}las3dpoly -i in.laz -poly line.shp -o out.laz -distance 10 -classify_as 13 -v{fcc}<br>classify all points within the result file as class 13 if they are within radial distance=10 to the line specified by line.shp and list a verbose report of what has been done.
                 """,
         "desc": f"{txt_las3dpoly_rad_short}",
     },
@@ -682,7 +681,7 @@ More merge and copy arguments see README file.
     "LasClip": {
         "disp": "lasclip",
         "help": f"""
-{txt_lasclip_short}                
+{txt_lasclip_short}
 Takes as input a LAS/LAZ/TXT file and a SHP/TXT file with one or many polygons (e.g. building footprints or flight lines), clips away all the points that fall outside all polygons (or inside some polygon), and stores the surviving points to the output LAS/LAZ/TXT file. Instead of clipping the points they can also be classified.
 <h3>Parameters</h3>
 {txt_inlazfile}
@@ -702,10 +701,10 @@ Takes as input a LAS/LAZ/TXT file and a SHP/TXT file with one or many polygons (
 {txt_lasreturn_intro}
 <h3>Parameters</h3>
 {txt_inlazfile}
-{fop}print histogram about returns:{fcc} print histogram about missing or duplicate returns  
-{fop}adds attribute 'gap to next return':{fcc} adds an attribute 'gap to next return' as "extra bytes" and stores the 3D distance from the current to the next return of the same pulse for all pulses that have multiple returns  
-{fop}repair invalid number of returns:{fcc} repair invalid number of return values  
-{fop}skip incomplete returns:{fcc} skip incomplete returns  
+{fop}print histogram about returns:{fcc} print histogram about missing or duplicate returns
+{fop}adds attribute 'gap to next return':{fcc} adds an attribute 'gap to next return' as "extra bytes" and stores the 3D distance from the current to the next return of the same pulse for all pulses that have multiple returns
+{fop}repair invalid number of returns:{fcc} repair invalid number of return values
+{fop}skip incomplete returns:{fcc} skip incomplete returns
 {txt_args("lasreturn")}
 {txt_verbose}
 {txt_64bit}
@@ -722,10 +721,10 @@ Takes as input a LAS/LAZ/TXT file and a SHP/TXT file with one or many polygons (
 {txt_lasreturn_intro}
 <h3>Parameters</h3>
 {txt_inlazfile}
-{fop}print histogram about returns:{fcc} print histogram about missing or duplicate returns  
-{fop}adds attribute 'gap to next return':{fcc} adds an attribute 'gap to next return' as "extra bytes" and stores the 3D distance from the current to the next return of the same pulse for all pulses that have multiple returns  
-{fop}repair invalid number of returns:{fcc} repair invalid number of return values  
-{fop}skip incomplete returns:{fcc} skip incomplete returns  
+{fop}print histogram about returns:{fcc} print histogram about missing or duplicate returns
+{fop}adds attribute 'gap to next return':{fcc} adds an attribute 'gap to next return' as "extra bytes" and stores the 3D distance from the current to the next return of the same pulse for all pulses that have multiple returns
+{fop}repair invalid number of returns:{fcc} repair invalid number of return values
+{fop}skip incomplete returns:{fcc} skip incomplete returns
 {txt_args("lasreturn")}
 {txt_verbose}
 {txt_64bit}
@@ -744,7 +743,7 @@ Takes as input a LAS/LAZ/TXT file and a SHP/TXT file with one or many polygons (
 {txt_64bit}
 {head_console_examples}
 {foe}lassort64 *.laz{fcc}<br>z-orders all LAZ files with a default bucket size.""",
-        "desc": f"txt_lassort_short",
+        "desc": "txt_lassort_short",
     },
     "LasSortPro": {
         "disp": "lassort (folder)",
@@ -760,7 +759,7 @@ Takes as input a LAS/LAZ/TXT file and a SHP/TXT file with one or many polygons (
 {head_console_examples}
 {foe}lassort64 flight1*.las flight2*.las -gps_time{fcc}<br>sorts all LAS files by their GPS time
 {foe}lassort64 *.las -olaz -point_source{fcc}<br>sorts all LAS files by their point source ID and stores them compressed""",
-        "desc": f"txt_lassort_short",
+        "desc": "txt_lassort_short",
     },
     "LasDiff": {
         "disp": "lasdiff",
@@ -790,7 +789,7 @@ Takes as input a LAS/LAZ/TXT file and a SHP/TXT file with one or many polygons (
     {foe}lasindex -i in.laz{fcc}<br>creates a spatial indexing file called 'in.lax' that need to be in the same folder as the file 'in.laz' to be useful. If you modify the spatial location, the number of points, or their order in the file then you need to recreate the LAX file.
     {foe}lasindex -i in.laz -append{fcc}<br>same as above but append the index to the LAZ file (only LAZ files).
                 """,
-        "desc": f"txt_lasindex_short",
+        "desc": "txt_lasindex_short",
     },
     "LasIndexPro": {
         "disp": "lasindex (folder)",
@@ -806,7 +805,7 @@ Takes as input a LAS/LAZ/TXT file and a SHP/TXT file with one or many polygons (
 {head_console_examples}
     {foe}lasindex -i *.laz -dont_reindex{fcc}<br>creates a spatial indexing file for all LAZ files that do not yet have a LAX file yet.
                 """,
-        "desc": f"txt_lasindex_short",
+        "desc": "txt_lasindex_short",
     },
     "LasProbe": {
         "disp": "lasprobe",
@@ -827,7 +826,7 @@ The output report defaults to stdout unless you specify an output file with '-o 
 {head_console_examples}
 {foe}lasprobe64 -i ..\data\fusa.laz -probe 277760.00 6122260 52.14{fcc}<br>probes all LiDAR points including buildings, wires and vegetation and outputs the computed elevation "52.14" to stdout
 {foe}lasprobe64 -i ..\data\fusa.laz -probe 277760.00 6122260 -o mist.txt{fcc}<br>probes all LiDAR points including buildings, wires and vegetation and outputs the computed elevation "52.14" to text file 'mist.txt'""",
-        "desc": f"txt_lasprobe_short",
+        "desc": "txt_lasprobe_short",
     },
     "LasIntensity": {
         "disp": "lasintensity",
@@ -1446,7 +1445,7 @@ This example analyzes all raw integer coordinates of "in.laz" into three separat
 {head_console_examples}
   {foe}lasinfo -i *.laz -no_vlrs -nc -otxt{fcc}<br>create a textfile to each LAZ file containing the header information without point parsing and VLR information.
   {foe}lasinfo -i *.laz -no_vlrs -nc -stdout > all.txt
-create ONE textfile with all LAZ file header information.  
+create ONE textfile with all LAZ file header information.
                 """,
         "desc": f"{txt_lasinfo_short}",
     },
@@ -1478,7 +1477,7 @@ create ONE textfile with all LAZ file header information.
 {txt_verbose}
 {txt_64bit}
 {head_console_examples}
-    {foe}lasoverlap -i LDR*.las -files_are_flightlines -step 3 -min_diff 0.1 -max_diff 0.4 -o overlap.png{fcc}<br>merges all the files "LDR*.las" while assigning the points of each file a unique point source ID (aka flight line number), and then creates an overlap raster as well as a difference raster with a step of 3 units. The overlap raster uses the default range of 5 overlaps lines for the color ramp. The difference raster uses '-min_diff 0.1' and '-max_diff 0.4' which maps the range (-0.4 ... -0.1) to (blue ... white) and the range (0.1 ... 0.4) to (white ... red). The range (-0.1 ... 0.1) is mapped to white.  
+    {foe}lasoverlap -i LDR*.las -files_are_flightlines -step 3 -min_diff 0.1 -max_diff 0.4 -o overlap.png{fcc}<br>merges all the files "LDR*.las" while assigning the points of each file a unique point source ID (aka flight line number), and then creates an overlap raster as well as a difference raster with a step of 3 units. The overlap raster uses the default range of 5 overlaps lines for the color ramp. The difference raster uses '-min_diff 0.1' and '-max_diff 0.4' which maps the range (-0.4 ... -0.1) to (blue ... white) and the range (0.1 ... 0.4) to (white ... red). The range (-0.1 ... 0.1) is mapped to white.
                 """,
         "desc": f"{txt_lasoverlap_short}",
     },
@@ -1533,7 +1532,7 @@ create ONE textfile with all LAZ file header information.
     "LasColor": {
         "disp": "lascolor",
         "help": f"""
-{txt_lascolor_intro} 
+{txt_lascolor_intro}
 <h3>Parameters</h3>
 {txt_inlazfile}
 {fop}input ortho:{fcc} input file as georeferenced TIF file.
@@ -1586,84 +1585,84 @@ create ONE textfile with all LAZ file header information.
     },
     "FlightLinesToCHMFirstReturn": {
         "disp": "Flightlines to CHM - first return",
-        "help": f"""
+        "help": """
                     Create a canopy height model with first return only
                 """,
         "desc": "Create a canopy height model with first return only",
     },
     "FlightLinesToCHMHighestReturn": {
         "disp": "Flightlines to CHM - highest return",
-        "help": f"""
+        "help": """
                     Create a canopy height model with highest return only
                 """,
         "desc": "Create a canopy height model with highest return only",
     },
     "FlightLinesToCHMSpikeFree": {
         "disp": "Flightlines to CHM - spike free",
-        "help": f"""
+        "help": """
                     Create a canopy height model with spike free option
                 """,
         "desc": "Create a canopy height model with spike free option",
     },
     "FlightLinesToDTMandDSMFirstReturn": {
         "disp": "FlightLines to DTM & DSM - first return",
-        "help": f"""
+        "help": """
                      Create a digital terrain model and digital surface model out of lidar data files using the first return only
                 """,
         "desc": "Create a digital terrain model and digital surface model out of lidar data files using the first return only",
     },
     "FlightLinesToDTMandDSMSpikeFree": {
         "disp": "FlightLines to DTM & DSM - spike free",
-        "help": f"""
+        "help": """
                     Create a digital terrain model and digital surface model with spike free option
                 """,
         "desc": "Create a digital terrain model and digital surface model with spike free option",
     },
     "FlightLinesToMergedCHMFirstReturn": {
         "disp": "FlightLines to merged CHM - first return",
-        "help": f"""
+        "help": """
                     Create a merged canopy height model out of lidar data files using the first return only
                 """,
         "desc": "Create a merged canopy height model out of lidar data files using the first return only",
     },
     "FlightLinesToMergedCHMHighestReturn": {
         "disp": "FlightLines to merged CHM - highest return",
-        "help": f"""
+        "help": """
                     Create a merged canopy height model out of lidar data files with highest return
                 """,
         "desc": "Create a merged canopy height model out of lidar data files with highest return",
     },
     "FlightLinesToMergedCHMPitFree": {
         "disp": "FlightLines to merged CHM - pit free",
-        "help": f"""
+        "help": """
                     Create a pit free merged canopy height model out of lidar data files
                 """,
         "desc": "Create a pit free merged canopy height model out of lidar data files",
     },
     "FlightLinesToMergedCHMSpikeFree": {
         "disp": "FlightLines to merged CHM - spike free",
-        "help": f"""
+        "help": """
                     Create a canopy height model out of lidar data files which are optional in flightlines
                 """,
         "desc": "Create a canopy height model out of lidar data files which are optional in flightlines",
     },
     "HugeFileClassify": {
         "disp": "Huge file - classify",
-        "help": f"""
+        "help": """
                     Do a classification for huge lidar data files
                 """,
         "desc": "Do a classification for huge lidar data files",
     },
     "HugeFileGroundClassify": {
         "disp": "Huge file - ground classify",
-        "help": f"""
+        "help": """
                     Do a ground classification for huge lidar data files
                 """,
         "desc": "Do a ground classification for huge lidar data files",
     },
     "HugeFileNormalize": {
         "disp": "Huge file - normalize",
-        "help": f"""
+        "help": """
                     Normalize huge lidar data files
                 """,
         "desc": "Normalize huge lidar data files",

--- a/LAStools/lastools/core/utils/utils.py
+++ b/LAStools/lastools/core/utils/utils.py
@@ -79,6 +79,9 @@ class LastoolsUtils:
     def run_lastools(commands, feedback):
         if ("-gui" in commands) and ("-cpu64" in commands):
             feedback.reportError("Parameters '64 bit' and 'open LAStools GUI' can't be combined")
+        if (commands[0].endswith('64.exe"') or commands[0].endswith('64"')) and "-cpu64" in commands:
+            feedback.pushWarning("Parameter '64 bit' can't be combined with 64 bit executable. Removing '-cpu64'")
+            commands.remove("-cpu64")
         commandline = " ".join(commands)
         feedback.pushConsoleInfo("LAStools command line")
         feedback.pushConsoleInfo(commandline)

--- a/LAStools/lastools/core/utils/utils.py
+++ b/LAStools/lastools/core/utils/utils.py
@@ -53,17 +53,27 @@ class LastoolsUtils:
             return ""
 
     @staticmethod
+    def lastools_windows_path():
+        lastools_folder = Path(ProcessingConfig.getSetting("LASTOOLS_FOLDER"))
+        return (None, lastools_folder)
+
+    @staticmethod
+    def lastools_linux_path():
+        lastools_folder = Path(ProcessingConfig.getSetting("LASTOOLS_FOLDER"))
+        wine_setting = ProcessingConfig.getSetting("WINE_FOLDER")
+
+        if wine_setting is None or wine_setting == "":
+            return (None, lastools_folder)
+
+        wine_folder = Path(wine_setting)
+        return (wine_folder, lastools_folder)
+
+    @staticmethod
     def lastools_path():
-        lastools_folder = ProcessingConfig.getSetting("LASTOOLS_FOLDER")
         if isWindows():
-            wine_folder = ""
+            return LastoolsUtils.lastools_windows_path()
         else:
-            wine_folder = ProcessingConfig.getSetting("WINE_FOLDER")
-        if (wine_folder is None) or (wine_folder == ""):
-            folder = lastools_folder
-        else:
-            folder = wine_folder + "/wine " + lastools_folder
-        return folder
+            return LastoolsUtils.lastools_linux_path()
 
     @staticmethod
     def run_lastools(commands, feedback):

--- a/LAStools/lastools/core/utils/utils.py
+++ b/LAStools/lastools/core/utils/utils.py
@@ -21,12 +21,25 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 import subprocess
+from pathlib import Path
 
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.tools.system import isWindows
 
 
 class LastoolsUtils:
+    @staticmethod
+    def validate_config_paths():
+        wine_path, lastools_path = LastoolsUtils.lastools_path()
+        if not lastools_path.exists():
+            return False
+        if not isWindows():
+            if wine_path is None or wine_path == Path(""):
+                return False
+            if not wine_path.exists():
+                return False
+        return True
+
     @staticmethod
     def has_wine():
         wine_folder = ProcessingConfig.getSetting("WINE_FOLDER")

--- a/LAStools/lastools/core/utils/utils.py
+++ b/LAStools/lastools/core/utils/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     utils.py
@@ -26,8 +24,6 @@ import subprocess
 
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.tools.system import isWindows
-from qgis.utils import iface
-from qgis.core import Qgis, QgsMessageLog
 
 
 class LastoolsUtils:

--- a/LAStools/lastools/core/visualization_colorization/__init__.py
+++ b/LAStools/lastools/core/visualization_colorization/__init__.py
@@ -1,7 +1,8 @@
-from .lasview import LasView, LasViewPro
 from .lascolor import LasColor
+from .lasview import LasView, LasViewPro
 
 __all__ = [
-    LasView, LasViewPro,
-    LasColor
+    LasView,
+    LasViewPro,
+    LasColor,
 ]

--- a/LAStools/lastools/core/visualization_colorization/lascolor.py
+++ b/LAStools/lastools/core/visualization_colorization/lascolor.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -42,13 +41,7 @@ class LasColor(LastoolsAlgorithm):
         self.add_parameters_point_output_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_64_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         self.add_parameters_generic_input_commands(parameters, context, commands, "-image")

--- a/LAStools/lastools/core/visualization_colorization/lascolor.py
+++ b/LAStools/lastools/core/visualization_colorization/lascolor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lascolor.py
@@ -23,10 +21,10 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasColor(LastoolsAlgorithm):

--- a/LAStools/lastools/core/visualization_colorization/lasview.py
+++ b/LAStools/lastools/core/visualization_colorization/lasview.py
@@ -19,7 +19,6 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-import os
 
 from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
 from qgis.PyQt.QtGui import QIcon
@@ -58,13 +57,7 @@ class LasView(LastoolsAlgorithm):
         self.add_parameters_verbose_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_commands(parameters, context, commands)
         self.add_parameters_point_input_commands(parameters, context, commands)
         points = self.parameterAsInt(parameters, self.POINTS, context)
@@ -141,13 +134,7 @@ class LasViewPro(LastoolsAlgorithm):
         self.add_parameters_verbose_gui()
 
     def processAlgorithm(self, parameters, context, feedback):
-        commands = [
-            os.path.join(
-                LastoolsUtils.lastools_path(),
-                "bin",
-                self.LASTOOL + self.cpu64(parameters, context) + LastoolsUtils.command_ext(),
-            )
-        ]
+        commands = [self.get_command(parameters, context)]
         self.add_parameters_verbose_gui_commands(parameters, context, commands)
         self.add_parameters_point_input_folder_commands(parameters, context, commands)
         self.add_parameters_files_are_flightlines_commands(parameters, context, commands)

--- a/LAStools/lastools/core/visualization_colorization/lasview.py
+++ b/LAStools/lastools/core/visualization_colorization/lasview.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lasview.py
@@ -23,11 +21,11 @@ __copyright__ = "(c) 2025, rapidlasso GmbH"
 
 import os
 
-from PyQt5.QtGui import QIcon
-from qgis.core import QgsProcessingParameterNumber, QgsProcessingParameterEnum
+from qgis.core import QgsProcessingParameterEnum, QgsProcessingParameterNumber
+from qgis.PyQt.QtGui import QIcon
 
-from ..utils import LastoolsUtils, lastool_info, lasgroup_info, paths, licence, help_string_help, readme_url
 from ..algo import LastoolsAlgorithm
+from ..utils import LastoolsUtils, help_string_help, lasgroup_info, lastool_info, licence, paths, readme_url
 
 
 class LasView(LastoolsAlgorithm):

--- a/LAStools/lastools_plugin.py
+++ b/LAStools/lastools_plugin.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 ***************************************************************************
     lastools_plugin.py
@@ -17,15 +15,16 @@
 ***************************************************************************
 """
 
-__author__ = 'rapidlasso'
-__date__ = 'September 2023'
-__copyright__ = '(C) 2023, rapidlasso GmbH'
+__author__ = "rapidlasso"
+__date__ = "September 2023"
+__copyright__ = "(C) 2023, rapidlasso GmbH"
 
+import inspect
 import os
 import sys
-import inspect
 
-from qgis.core import QgsProcessingAlgorithm, QgsApplication
+from qgis.core import QgsApplication
+
 from .lastools_provider import LAStoolsProvider
 
 cmd_folder = os.path.split(inspect.getfile(inspect.currentframe()))[0]
@@ -33,9 +32,10 @@ cmd_folder = os.path.split(inspect.getfile(inspect.currentframe()))[0]
 if cmd_folder not in sys.path:
     sys.path.insert(0, cmd_folder)
 
+
 class LAStoolsPlugin(object):
 
-    def __init__(self,iface):
+    def __init__(self, iface):
         self.provider = LAStoolsProvider()
 
     def initGui(self):

--- a/LAStools/lastools_provider.py
+++ b/LAStools/lastools_provider.py
@@ -140,7 +140,7 @@ class LAStoolsProvider(QgsProcessingProvider):
         ProcessingConfig.settingIcons[self.name()] = self.icon()
         ProcessingConfig.addSetting(Setting(self.name(), "LASTOOLS_ACTIVATED", "Activate", True))
         ProcessingConfig.addSetting(
-            Setting(self.name(), "LASTOOLS_FOLDER", "LAStools folder", "C:\LAStools", valuetype=Setting.FOLDER)
+            Setting(self.name(), "LASTOOLS_FOLDER", "LAStools folder", "C:/LAStools", valuetype=Setting.FOLDER)
         )
         ProcessingConfig.addSetting(Setting(self.name(), "WINE_FOLDER", "Wine folder", "", valuetype=Setting.FOLDER))
         ProcessingConfig.readSettings()

--- a/LAStools/lastools_provider.py
+++ b/LAStools/lastools_provider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 /***************************************************************************
     lastools_provider.py
@@ -21,101 +19,54 @@ __author__ = "rapidlasso"
 __date__ = "January 2025"
 __copyright__ = "(c) 2025, rapidlasso GmbH"
 
-from PyQt5.QtGui import QIcon
+from processing.core.ProcessingConfig import ProcessingConfig, Setting
 from qgis.core import QgsProcessingProvider
-from processing.core.ProcessingConfig import Setting, ProcessingConfig
+from qgis.PyQt.QtGui import QIcon
 
-from .lastools.core.processing import (
-    LasIndex,
-    LasIndexPro,
-    LasMerge,
-    LasMergePro,
-    LasOverage,
-    LasOveragePro,
-    LasBoundary,
-    LasBoundaryPro,
-    LasClip,
-    LasPrecision,
-    LasTile,
-    LasTilePro,
-    LasSplit,
-    LasSort,
-    LasSortPro,
-    LasNoise,
-    LasNoisePro,
-    LasDiff,
-    LasCopy,
-    LasDistance,
-    LasDuplicate,
-    LasDuplicatePro,
-    Las3dPolyHorizontalVerticalDistance,
-    Las3dPolyRadialDistance,
-    LasIntensity,
-    LasIntensityAttenuationFactor,
-)
-from .lastools.core.data_convert import (
-    Las2txt,
-    Las2txtPro,
-    Txt2Las,
-    Txt2LasPro,
-    Las2LasFilter,
-    Las2LasProFilter,
-    Las2LasProject,
-    Las2LasProProject,
-    Las2LasTransform,
-    Las2LasProTransform,
-    Las2Shp,
-    Shp2Las,
-    e572las,
-)
 from .lastools.core.classification_filtering import (
-    LasGround,
-    LasGroundPro,
-    LasGroundNew,
-    LasGroundProNew,
     LasClassify,
     LasClassifyPro,
+    LasGround,
+    LasGroundNew,
+    LasGroundPro,
+    LasGroundProNew,
     LasThin,
     LasThinPro,
 )
 from .lastools.core.data_compression import LasZip, LasZipPro
+from .lastools.core.data_convert import (
+    Las2LasFilter,
+    Las2LasProFilter,
+    Las2LasProject,
+    Las2LasProProject,
+    Las2LasProTransform,
+    Las2LasTransform,
+    Las2Shp,
+    Las2txt,
+    Las2txtPro,
+    Shp2Las,
+    Txt2Las,
+    Txt2LasPro,
+    e572las,
+)
 from .lastools.core.dsm_dtm_generation_prodctions import (
+    Blast2Dem,
+    Blast2DemPro,
+    Blast2Iso,
+    Blast2IsoPro,
     Las2Dem,
     Las2DemPro,
     Las2Iso,
-    LasPlanes,
+    LasCanopy,
+    LasCanopyPro,
     LasGrid,
     LasGridPro,
     LasHeight,
     LasHeightClassify,
     LasHeightPro,
     LasHeightProClassify,
-    LasCanopy,
-    LasCanopyPro,
+    LasPlanes,
     LasVoxel,
-    Blast2Dem,
-    Blast2DemPro,
-    Blast2Iso,
-    Blast2IsoPro,
-)
-from .lastools.core.publishing import LasPublish, LasPublishPro
-from .lastools.core.quality_control_information import (
-    LasInfo,
-    LasInfoPro,
-    LasOverlap,
-    LasOverlapPro,
-    LasControl,
-    LasProbe,
-    LasReturn,
-    LasReturnPro,
-    LasValidate,
-    LasValidatePro,
-    LasOptimize,
-)
-from .lastools.core.visualization_colorization import (
-    LasView,
-    LasViewPro,
-    LasColor,
 )
 from .lastools.core.pipelines import (
     FlightLinesToCHMFirstReturn,
@@ -128,10 +79,53 @@ from .lastools.core.pipelines import (
     FlightLinesToMergedCHMPitFree,
     FlightLinesToMergedCHMSpikeFree,
     HugeFileClassify,
-    HugeFileNormalize,
     HugeFileGroundClassify,
+    HugeFileNormalize,
+)
+from .lastools.core.processing import (
+    Las3dPolyHorizontalVerticalDistance,
+    Las3dPolyRadialDistance,
+    LasBoundary,
+    LasBoundaryPro,
+    LasClip,
+    LasCopy,
+    LasDiff,
+    LasDistance,
+    LasDuplicate,
+    LasDuplicatePro,
+    LasIndex,
+    LasIndexPro,
+    LasIntensity,
+    LasIntensityAttenuationFactor,
+    LasMerge,
+    LasMergePro,
+    LasNoise,
+    LasNoisePro,
+    LasOverage,
+    LasOveragePro,
+    LasPrecision,
+    LasSort,
+    LasSortPro,
+    LasSplit,
+    LasTile,
+    LasTilePro,
+)
+from .lastools.core.publishing import LasPublish, LasPublishPro
+from .lastools.core.quality_control_information import (
+    LasControl,
+    LasInfo,
+    LasInfoPro,
+    LasOptimize,
+    LasOverlap,
+    LasOverlapPro,
+    LasProbe,
+    LasReturn,
+    LasReturnPro,
+    LasValidate,
+    LasValidatePro,
 )
 from .lastools.core.utils import paths
+from .lastools.core.visualization_colorization import LasColor, LasView, LasViewPro
 
 
 class LAStoolsProvider(QgsProcessingProvider):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,79 @@
+[tool.flake8]
+count = true
+exclude = [
+    ".git",
+    "**pycache**",
+    "docs/conf.py",
+    "old",
+    "build",
+    "dist",
+    ".venv*",
+    "tests",
+    "*/external/*",
+    "ext_libs/*"
+]
+ignore = ["E121", "E123", "E126", "E203", "E226", "E24", "E704", "QGS105", "W503", "W504"]
+max-complexity = 15
+max-doc-length = 130
+max-line-length = 120
+output-file = "dev_flake8_report.txt"
+statistics = true
+tee = true
+
+[tool.black]
+line-length = 120
+target-version = ["py39"]
+
+[tool.isort]
+ensure_newline_before_comments = true
+force_grid_wrap = 0
+include_trailing_comma = true
+line_length = 120
+multi_line_output = 3
+profile = "black"
+use_parentheses = true
+
+[tool.pytest.ini_options]
+addopts = [
+    "--junitxml=junit/test-results.xml",
+    "--cov-config=pyproject.toml",
+    "--cov=pyqgisgmsher",
+    "--cov-report=html",
+    "--cov-report=term",
+    "--cov-report=xml",
+    "--ignore=tests/_wip/"
+]
+norecursedirs = [
+    ".*",
+    "build",
+    "dev",
+    "development",
+    "dist",
+    "docs",
+    "CVS",
+    "fixtures",
+    "*darcs",
+    "{arch}",
+    "*.egg",
+    "venv",
+    "*wip"
+]
+python_files = ["test_*.py"]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+omit = [
+    ".venv/*",
+    "*tests*"
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "if self.debug:",
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:"
+]
+ignore_errors = true
+show_missing = true

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,0 +1,12 @@
+# Develoment dependencies
+# -----------------------
+
+black
+
+flake8-builtins>=2.2
+flake8-eradicate>=1.5
+flake8-isort>=6.1
+flake8-qgis>=1
+
+isort>=5.13
+pre-commit>=3,<4


### PR DESCRIPTION
Built on top of #21 

1. Add method to validate config LASTOOLS folder and WINE folder
   Previously it only checks if LASTOOLS folder was not empty
2. Add method to generate command in `processAlgorithm()`
   Generated command now looks like `"C:/Program Files/LAStools/bin/blast2dem64" -i "C:/Users [...]` instead of `C:\Program Files\LAStools/bin/blast2dem64 -i "C:/Users [...]`
   No more error if LasTools install forlder path contains
3. Fixes #22