### PR TITLE
Ensure 'wine' is appended to the Wine folder once and only once.

### DIFF
--- a/LAStools/lastools/core/algo/lastools_algorithm.py
+++ b/LAStools/lastools/core/algo/lastools_algorithm.py
@@ -156,8 +156,8 @@ class LastoolsAlgorithm(QgsProcessingAlgorithm):
             commands.insert(1,"-demo")
         # add optional wine
         if not isWindows() and LastoolsUtils.has_wine():
-            command_prefix = self.pathwrap(LastoolsUtils.wine_folder())
-            commands.insert(0,command_prefix)
+            wine_path = LastoolsUtils.wine_folder()
+            commands.insert(0,self.pathwrap(os.path.join(wine_path,"wine")))
         #
         if ("-gui" in commands) and (self.isCpu64):
             feedback.reportError("GUI not available at 64 bit")


### PR DESCRIPTION
Recent changes to Wine path construction still result in a broken command line on macOS. This patch retrieves the wine_folder parameter, appends "wine", then uses the new method pathwrap to handle spaces.

If it's simpler to fix this another way, that's fine. I don't need the credit.

```
--- a/LAStools/lastools/core/algo/lastools_algorithm.py
+++ b/LAStools/lastools/core/algo/lastools_algorithm.py
@@ -156,8 +156,8 @@ class LastoolsAlgorithm(QgsProcessingAlgorithm):
             commands.insert(1,"-demo")
         # add optional wine
         if not isWindows() and LastoolsUtils.has_wine():
-            command_prefix = self.pathwrap(LastoolsUtils.wine_folder())
-            commands.insert(0,command_prefix)
+            wine_path = LastoolsUtils.wine_folder()
+            commands.insert(0,self.pathwrap(os.path.join(wine_path,"wine")))
         #
         if ("-gui" in commands) and (self.isCpu64):
             feedback.reportError("GUI not available at 64 bit")
```